### PR TITLE
Remove loss chart and disable automatic board growth

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,8 +220,8 @@ select{
 }
 .split{
   display:grid;
-  grid-template-columns:1fr 1fr;
   gap:12px;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
 }
 canvas.chart{
   width:100%;
@@ -461,10 +461,6 @@ footer{
       <div>
         <h2>Reward / episod</h2>
         <canvas id="chartReward" class="chart" width="400" height="140"></canvas>
-      </div>
-      <div>
-        <h2>Förlust</h2>
-        <canvas id="chartLoss" class="chart" width="400" height="140"></canvas>
       </div>
     </div>
 
@@ -2283,7 +2279,6 @@ const ui={
   kBest:document.getElementById('kBest'),
   kFruitRate:document.getElementById('kFruitRate'),
   chartReward:new MiniLine(document.getElementById('chartReward')),
-  chartLoss:new MiniLine(document.getElementById('chartLoss')),
   tabTraining:document.getElementById('tabTraining'),
   tabGuide:document.getElementById('tabGuide'),
   trainingView:document.getElementById('trainingView'),
@@ -2592,8 +2587,6 @@ function resetTrainingStats(){
   lossHist.length=0;
   ui.chartReward.data=[];
   ui.chartReward.draw();
-  ui.chartLoss.data=[];
-  ui.chartLoss.draw();
   updateStatsUI();
 }
 function updateStatsUI(){
@@ -2614,16 +2607,6 @@ function flash(message,danger=false){
 }
 
 /* ---------------- Training loop ---------------- */
-function maybeGrowBoard(){
-  const frRate=avg(fruitHist,100);
-  const current=+ui.gridSize.value;
-  if(frRate>0.6 && current<+ui.gridSize.max){
-    const next=Math.min(+ui.gridSize.max,current+2);
-    ui.gridSize.value=next;
-    updateGridLabel();
-    resetEnvironment(next);
-  }
-}
 function createEpisodeContext(){
   const desired=+ui.gridSize.value;
   if(env.cols!==desired||env.rows!==desired){
@@ -2651,7 +2634,6 @@ async function performStep(ctx,mode,{respectStop=false}={}){
     const loss=await agent.learn();
     if(loss!==null && loss!==undefined){
       lossHist.push(loss);
-      ui.chartLoss.push(avg(lossHist,30));
     }
   }
   if(agent.kind==='dqn' && targetSyncSteps>0 && totalSteps%targetSyncSteps===0){
@@ -2677,7 +2659,6 @@ async function finalizeEpisode(ctx){
   const loss=await agent.finishEpisode(ctx);
   if(loss!==null && loss!==undefined){
     lossHist.push(loss);
-    ui.chartLoss.push(avg(lossHist,30));
   }
   episode++;
   rwHist.push(ctx.totalReward);
@@ -2688,7 +2669,6 @@ async function finalizeEpisode(ctx){
   ui.chartReward.push(ctx.totalReward);
   updateStatsUI();
   await tf.nextFrame();
-  maybeGrowBoard();
 }
 async function trainingLoop(ts){
   if(!training||watching){
@@ -2803,7 +2783,6 @@ async function buildAppState(){
       fruitHist:Array.from(fruitHist),
       lossHist:Array.from(lossHist),
       chartReward:Array.from(ui.chartReward.data),
-      chartLoss:Array.from(ui.chartLoss.data),
     },
   };
 }
@@ -2816,8 +2795,6 @@ function applyMeta(meta={}){
   assignArray(lossHist,meta.lossHist,v=>+v||0);
   ui.chartReward.data=Array.isArray(meta.chartReward)?meta.chartReward.map(v=>+v||0):[];
   ui.chartReward.draw();
-  ui.chartLoss.data=Array.isArray(meta.chartLoss)?meta.chartLoss.map(v=>+v||0):[];
-  ui.chartLoss.draw();
   updateStatsUI();
 }
 async function saveTrainingToFile(){


### PR DESCRIPTION
## Summary
- remove the loss chart panel and associated UI plumbing so only the reward chart remains
- adjust the split layout styling to let the remaining chart span the available space
- stop automatically growing the board, keeping the grid size under manual control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb5d523c083248b5c4fd2e52a6ae3