### PR TITLE
Add AutoTrain CLI with disk guard and vectorized env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
 # Snake-ML
-ML for snake
+
+Refactored reinforcement learning playground for the Snake environment with support for automated multi-day training and disk-aware checkpointing.
+
+## Highlights
+
+- **Vectorised environments** – `VecSnakeEnv` runs multiple `SnakeEnv` instances in parallel and feeds a shared replay buffer.
+- **AutoTrain mode** – adaptive scheduler tunes ε-greedy exploration, learning rate, PER hyperparameters, and reward weights within UI slider bounds. Curriculum automatically scales the board from 10×10 up to 20×20 as performance improves.
+- **Manual mode** – keeps fixed hyperparameters but allows selecting the number of parallel environments.
+- **Disk guardrails** – checkpoints and logs honour interval, cooldown, retention and disk size caps with atomic writes and automatic pruning.
+- **Evaluations & rollback** – lightweight greedy evaluations every 2000 episodes, best-model retention, and rollback on catastrophic regression.
+
+## CLI usage
+
+Training is handled through `train.js`. Install dependencies with `npm install` and start training, for example:
+
+```bash
+node train.js --mode auto   --envCount 12 --saveDir models/auto
+node train.js --mode manual --envCount 1  --saveDir models/manual
+```
+
+### Common flags
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `--mode auto\|manual` | Selects AutoTrain or Manual mode. | `auto` |
+| `--envCount` | Number of parallel environments. | auto: `12`, manual: `1` |
+| `--saveDir` | Directory for checkpoints/logs. | `models/<mode>` |
+| `--checkpoint-interval-episodes` | Minimum episodes between periodic checkpoints. | `5000` |
+| `--checkpoint-interval-minutes` | Minimum minutes between periodic checkpoints. | `60` |
+| `--retain-checkpoints` | Number of periodic checkpoints to keep (latest & best are always kept). | `5` |
+| `--save-cap-mb` | Maximum total size for `saveDir`. | `1024` |
+| `--log-cap-mb` | Maximum total size for log directory. | `200` |
+| `--retain-logs` | Number of rotated log archives to keep. | `3` |
+| `--log-interval-episodes` | Episode interval for JSONL summaries. | `500` |
+| `--console-interval-episodes` | Episode interval for console summaries. | `200` |
+| `--min-save-cooldown-minutes` | Cooldown for extra checkpoints (board changes, best eval). | `10` |
+
+Additional knobs map directly to hyperparameters: `--batchSize`, `--bufferSize`, `--gamma`, `--lr`, `--n-step`, `--target-sync`, `--priority-alpha`, `--priority-beta`, `--priority-beta-increment`, `--eps-start`, `--eps-end`, `--eps-decay`, `--board-size` (manual mode).
+
+### AutoTrain specifics
+
+- Curriculum upgrades board sizes at `maFruit500` > 60 (→14×14), > 120 (→18×18), and > 200 (→20×20). A checkpoint is triggered on each upgrade subject to cooldown.
+- Adaptive scheduler reacts to plateaus/regressions by adjusting ε schedule, cosine-annealed learning rate, PER α/β, n-step horizon, γ, and reward weights while respecting UI slider bounds.
+- Replay buffer is truncated by 50% of the oldest transitions when the board size increases to promote rapid adaptation.
+- Evaluations run every 2000 episodes; new best models require at least +5 fruits and +2 % improvement with a 10 minute cooldown.
+- If `maFruit100` drops 25 % beneath the best evaluation for ≥5000 episodes the trainer reloads the best checkpoint.
+
+### Manual mode
+
+Manual mode keeps all hyperparameters fixed but can still run multiple environments in parallel (`--envCount`). No auto-adjustments are performed; checkpoints/logging follow the same disk constraints as Auto mode.
+
+## Disk and log policy
+
+- **Atomic saves** – checkpoints are written to a temporary directory and renamed into place. Pointers `latest/` and `best/` are updated with atomic renames.
+- **Intervals & cooldowns** – periodic checkpoints require both the episode and time thresholds; extra checkpoints (board change/best eval) respect the 10 minute cooldown. Shutdown checkpoints honour the same constraints.
+- **Retention** – keep `latest/`, `best/`, and the most recent `--retain-checkpoints` periodic checkpoints while pruning the oldest ones or any exceeding `--save-cap-mb`.
+- **Log rotation** – `training_log.jsonl` is appended every `--log-interval-episodes`. Files rotate at 10 MB, compress with gzip, and obey `--retain-logs` plus the `--log-cap-mb` budget.
+
+## Watching the latest model
+
+In browsers that support the File System Access API, the “Titta” button can load the latest checkpoint (`saveDir/latest/checkpoint.json`). When prompted, choose the directory containing your checkpoints (e.g. `models/auto`). The UI imports the model weights and renders a smooth evaluation run.
+
+## Development
+
+- Source is written in modern ES modules (`package.json` sets `"type": "module"`).
+- TensorFlow.js Node bindings (`@tensorflow/tfjs-node`) are used for training.
+- All heavy file operations (checkpoint pruning, log rotation) run through the shared `DiskGuard` helper which rate-limits work to once every 30 seconds.
+
+## Example workflows
+
+```bash
+# Auto mode with 16 parallel environments and larger replay buffer
+node train.js --mode auto --envCount 16 --bufferSize 750000 --saveDir models/auto-exp
+
+# Manual mode, 4 environments, custom gamma and epsilon schedule
+node train.js --mode manual --envCount 4 --gamma 0.985 --eps-end 0.1 --saveDir models/manual-finetune
+```
+
+Logs and checkpoints are available inside the configured `saveDir`. `latest/checkpoint.json` always reflects the most recent successful save, while `best/checkpoint.json` tracks the best evaluation result.

--- a/index.html
+++ b/index.html
@@ -2359,6 +2359,7 @@ let currentAlgoKey='dueling';
 let playbackMode='cinematic';
 let training=false;
 let trainingToken=0;
+let checkpointDirHandle=null;
 let lastFrame=0;
 let currentEpisode=null;
 let targetSyncSteps=2000;
@@ -2814,6 +2815,14 @@ async function watchSmoothEpisode(){
   ui.btnWatch.disabled=true;
   try{
     await waitForRenderIdle();
+    if(window.showDirectoryPicker){
+      try{
+        const checkpoint=await readLatestCheckpoint();
+        await applyCheckpointData(checkpoint);
+      }catch(err){
+        console.warn('Kunde inte läsa latest-checkpoint',err);
+      }
+    }
     const desired=+ui.gridSize.value;
     if(env.cols!==desired||env.rows!==desired){
       resetEnvironment(desired,true);
@@ -2908,6 +2917,44 @@ async function saveTrainingToFile(){
     if(resume&&!watching) startTraining();
   }
 }
+async function ensureCheckpointDirectory(){
+  if(!window.showDirectoryPicker) throw new Error('Filåtkomst stöds inte i denna webbläsare');
+  if(!checkpointDirHandle){
+    checkpointDirHandle=await window.showDirectoryPicker({mode:'read'});
+  }
+  return checkpointDirHandle;
+}
+async function readLatestCheckpoint(){
+  const handle=await ensureCheckpointDirectory();
+  const latest=await handle.getDirectoryHandle('latest');
+  const fileHandle=await latest.getFileHandle('checkpoint.json');
+  const file=await fileHandle.getFile();
+  const text=await file.text();
+  return JSON.parse(text);
+}
+async function applyCheckpointData(data){
+  if(!data||!data.agent) throw new Error('Ogiltig checkpoint');
+  const kind=(data.agent.kind==='dqn')?'dueling':(AGENT_PRESETS[data.agent.kind]?data.agent.kind:'dueling');
+  const preset=AGENT_PRESETS[kind];
+  if(preset){
+    applyPresetToUI({...preset.defaults,...(data.agent.config||{})});
+  }
+  if(data.rewardConfig) applyRewardConfigToUI(data.rewardConfig);
+  if(typeof data.meta?.boardSize==='number'){
+    ui.gridSize.value=data.meta.boardSize;
+    updateGridLabel();
+    resetEnvironment(data.meta.boardSize,true);
+  }
+  instantiateAgent(kind,{useCurrentUI:true});
+  await agent.importState(data.agent);
+  applyConfigToAgent();
+  if(data.meta){
+    episode=+data.meta.episode||0;
+    totalSteps=+data.meta.totalSteps||+data.meta.steps||0;
+    updateStatsUI();
+  }
+}
+
 async function loadTrainingFromFile(file){
   if(!agent||!file) return;
   if(watching){

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "snake-ml",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "train": "node train.js"
+  },
+  "dependencies": {
+    "@tensorflow/tfjs-node": "^4.20.0"
+  }
+}

--- a/src/agents/dqn_agent.js
+++ b/src/agents/dqn_agent.js
@@ -1,0 +1,426 @@
+import * as tf from '@tensorflow/tfjs-node';
+import { NStepAccumulator } from '../replay/n_step.js';
+import { PrioritizedReplayBuffer } from '../replay/prioritized_buffer.js';
+import { RingBuffer, mean, std, percentile } from '../utils/ring_buffer.js';
+
+const DEFAULT_LAYERS = [256, 256, 128];
+
+export class DQNAgent {
+  constructor({
+    stateDim,
+    actionDim,
+    envCount = 1,
+    gamma = 0.98,
+    lr = 5e-4,
+    batchSize = 128,
+    bufferSize = 500000,
+    priorityAlpha = 0.6,
+    priorityBeta = 0.4,
+    priorityBetaIncrement = 0.000002,
+    priorityEps = 0.001,
+    epsStart = 1.0,
+    epsEnd = 0.12,
+    epsDecay = 80000,
+    targetSync = 2000,
+    nStep = 3,
+    dueling = true,
+    double = true,
+    layers = DEFAULT_LAYERS,
+    gradientClip = 10,
+    warmupSteps = 5000,
+  }) {
+    this.kind = 'dqn';
+    this.stateDim = stateDim;
+    this.actionDim = actionDim;
+    this.envCount = envCount;
+    this.gamma = gamma;
+    this.lr = lr;
+    this.batchSize = batchSize;
+    this.targetSync = targetSync;
+    this.gradientClip = gradientClip;
+    this.warmupSteps = warmupSteps;
+
+    this.epsStart = epsStart;
+    this.epsEnd = epsEnd;
+    this.epsDecay = epsDecay;
+    this.epsilon = epsStart;
+
+    this.trainStep = 0;
+    this.globalStep = 0;
+
+    this.buffer = new PrioritizedReplayBuffer(bufferSize, {
+      alpha: priorityAlpha,
+      beta: priorityBeta,
+      betaIncrement: priorityBetaIncrement,
+      priorityEps,
+    });
+
+    this.priorityAlpha = priorityAlpha;
+    this.priorityBeta = priorityBeta;
+    this.priorityBetaIncrement = priorityBetaIncrement;
+    this.priorityEps = priorityEps;
+
+    this.dueling = dueling;
+    this.double = double;
+    this.layers = layers.slice();
+
+    this.nStep = nStep;
+    this.nStepBuffers = Array.from({ length: envCount }, () => new NStepAccumulator(nStep, this.gamma));
+
+    this.optimizer = tf.train.adam(this.lr);
+    this.online = this.buildModel();
+    this.target = this.buildModel();
+    this.syncTarget();
+
+    this.lossHistory = new RingBuffer(2000);
+    this.tdHistory = new RingBuffer(4000);
+  }
+
+  buildModel() {
+    const input = tf.input({ shape: [this.stateDim] });
+    let x = input;
+    this.layers.forEach((units) => {
+      x = tf.layers.dense({ units, activation: 'relu', kernelInitializer: 'heNormal' }).apply(x);
+    });
+    let output;
+    if (this.dueling) {
+      const advantage = tf.layers
+        .dense({ units: 128, activation: 'relu', kernelInitializer: 'heNormal' })
+        .apply(x);
+      const advOut = tf.layers.dense({ units: this.actionDim, activation: 'linear' }).apply(advantage);
+      const value = tf.layers
+        .dense({ units: 128, activation: 'relu', kernelInitializer: 'heNormal' })
+        .apply(x);
+      const valOut = tf.layers.dense({ units: 1, activation: 'linear' }).apply(value);
+      output = tf.layers.add().apply([advOut, valOut]);
+    } else {
+      output = tf.layers.dense({ units: this.actionDim, activation: 'linear' }).apply(x);
+    }
+    return tf.model({ inputs: input, outputs: output });
+  }
+
+  dispose() {
+    this.online?.dispose();
+    this.target?.dispose();
+    this.optimizer?.dispose?.();
+  }
+
+  setEnvCount(count) {
+    if (count === this.envCount) return;
+    this.envCount = count;
+    this.nStepBuffers = Array.from({ length: this.envCount }, () => new NStepAccumulator(this.nStep, this.gamma));
+  }
+
+  setGamma(value) {
+    this.gamma = value;
+    this.nStepBuffers.forEach((buf) => buf.setConfig(this.nStep, this.gamma));
+  }
+
+  setLearningRate(value) {
+    if (value === this.lr) return;
+    this.lr = value;
+    this.optimizer.dispose?.();
+    this.optimizer = tf.train.adam(this.lr);
+  }
+
+  setNStep(value) {
+    const n = Math.max(1, value | 0);
+    if (n === this.nStep) return;
+    this.nStep = n;
+    this.nStepBuffers.forEach((buf) => buf.setConfig(this.nStep, this.gamma));
+  }
+
+  setBatchSize(size) {
+    this.batchSize = Math.max(1, size | 0);
+  }
+
+  setBufferSize(size) {
+    this.buffer.setCapacity(size);
+  }
+
+  setTargetSync(steps) {
+    this.targetSync = Math.max(1, steps | 0);
+  }
+
+  setPriorityAlpha(alpha) {
+    this.priorityAlpha = alpha;
+    this.buffer.setAlpha(alpha);
+  }
+
+  setPriorityBeta(beta) {
+    this.priorityBeta = beta;
+    this.buffer.setBeta(beta);
+  }
+
+  setPriorityBetaIncrement(inc) {
+    this.priorityBetaIncrement = inc;
+    this.buffer.setBetaIncrement(inc);
+  }
+
+  setPriorityEps(eps) {
+    this.priorityEps = eps;
+    this.buffer.setPriorityEps(eps);
+  }
+
+  setEpsilonSchedule({ start, end, decay }) {
+    if (start !== undefined) this.epsStart = start;
+    if (end !== undefined) this.epsEnd = end;
+    if (decay !== undefined) this.epsDecay = decay;
+    this.updateEpsilon(this.globalStep);
+  }
+
+  setGlobalStep(step) {
+    this.globalStep = step;
+    this.updateEpsilon(step);
+  }
+
+  updateEpsilon(step = this.globalStep) {
+    const t = Math.min(1, step / this.epsDecay);
+    this.epsilon = this.epsStart * (1 - t) + this.epsEnd * t;
+    return this.epsilon;
+  }
+
+  syncTarget() {
+    this.target.setWeights(this.online.getWeights());
+  }
+
+  act(state) {
+    if (Math.random() < this.epsilon) {
+      return (Math.random() * this.actionDim) | 0;
+    }
+    return tf.tidy(() => {
+      const tensor = tf.tensor2d([state], [1, this.stateDim]);
+      const action = this.online.predict(tensor).argMax(1).dataSync()[0];
+      tensor.dispose();
+      return action;
+    });
+  }
+
+  greedyAction(state) {
+    return tf.tidy(() => {
+      const tensor = tf.tensor2d([state], [1, this.stateDim]);
+      const action = this.online.predict(tensor).argMax(1).dataSync()[0];
+      tensor.dispose();
+      return action;
+    });
+  }
+
+  recordTransition(envIndex, state, action, reward, nextState, done, weight = 1) {
+    const buffer = this.nStepBuffers[envIndex];
+    if (!buffer) return;
+    const ready = buffer.push({ s: state, a: action, r: reward, ns: nextState, d: done });
+    ready.forEach((sample) => this.buffer.push({ ...sample, w: weight }));
+    if (done) {
+      const tail = buffer.flush();
+      tail.forEach((sample) => this.buffer.push({ ...sample, w: weight }));
+    }
+  }
+
+  flushTransitions() {
+    this.nStepBuffers.forEach((buffer) => {
+      const tail = buffer.flush();
+      tail.forEach((sample) => this.buffer.push(sample));
+    });
+  }
+
+  async learn(repeats = 1) {
+    if (this.buffer.size() < Math.max(this.batchSize, this.warmupSteps)) {
+      return null;
+    }
+    let result = null;
+    for (let i = 0; i < repeats; i++) {
+      result = await this._learnOnce();
+    }
+    return result;
+  }
+
+  async _learnOnce() {
+    const sample = this.buffer.sample(this.batchSize);
+    if (!sample) return null;
+    const { batch, indices, weights } = sample;
+
+    const states = tf.tensor2d(batch.map((item) => Array.from(item.s)), [batch.length, this.stateDim]);
+    const nextStates = tf.tensor2d(batch.map((item) => Array.from(item.ns)), [batch.length, this.stateDim]);
+    const actions = tf.tensor1d(batch.map((item) => item.a), 'int32');
+    const rewards = tf.tensor1d(batch.map((item) => item.r));
+    const dones = tf.tensor1d(batch.map((item) => (item.d ? 1 : 0)));
+    const isWeights = tf.tensor1d(weights.length ? weights : new Array(batch.length).fill(1));
+
+    let tdTensor;
+    const { value: lossTensor, grads } = tf.variableGrads(() => {
+      const qPredAll = this.online.apply(states);
+      const actionMask = tf.oneHot(actions, this.actionDim);
+      const qPred = qPredAll.mul(actionMask).sum(1);
+
+      const nextQOnline = this.online.apply(nextStates);
+      const nextActions = this.double ? nextQOnline.argMax(1) : null;
+      const nextQTargetAll = this.target.apply(nextStates);
+      let nextQ;
+      if (this.double) {
+        const nextMask = tf.oneHot(nextActions, this.actionDim);
+        nextQ = nextQTargetAll.mul(nextMask).sum(1);
+      } else {
+        nextQ = nextQTargetAll.max(1);
+      }
+      const targets = rewards.add(nextQ.mul(tf.scalar(1).sub(dones)).mul(this.gamma));
+      tdTensor = targets.sub(qPred);
+      const loss = tdTensor.square().mul(isWeights).mean();
+      return loss;
+    }, this.online.trainableWeights);
+
+    const gradList = this.online.trainableWeights.map((weight) => grads[weight.name]);
+    const [clipped, globalNorm] = tf.clipByGlobalNorm(gradList, this.gradientClip);
+    const gradMap = {};
+    this.online.trainableWeights.forEach((weight, idx) => {
+      gradMap[weight.name] = clipped[idx];
+    });
+    this.optimizer.applyGradients(gradMap);
+
+    const lossValue = (await lossTensor.data())[0];
+    const tdErrors = Array.from(await tdTensor.abs().data());
+    this.buffer.updatePriorities(indices, tdErrors);
+    tdErrors.forEach((err) => this.tdHistory.push(err));
+
+    this.trainStep += 1;
+    if (this.targetSync > 0 && this.trainStep % this.targetSync === 0) {
+      this.syncTarget();
+    }
+
+    this.lossHistory.push(lossValue);
+
+    // Clean up tensors
+    lossTensor.dispose();
+    tdTensor.dispose();
+    states.dispose();
+    nextStates.dispose();
+    actions.dispose();
+    rewards.dispose();
+    dones.dispose();
+    isWeights.dispose();
+    gradList.forEach((grad) => grad.dispose());
+    clipped.forEach((grad) => grad.dispose());
+    globalNorm.dispose();
+
+    return { loss: lossValue, tdErrors };
+  }
+
+  getLossStats(window = 500) {
+    const values = this.lossHistory.toArray().slice(-window);
+    return {
+      mean: mean(values),
+      std: std(values),
+    };
+  }
+
+  getTdErrorStats(window = 1000) {
+    const values = this.tdHistory.toArray().slice(-window).filter(Number.isFinite);
+    if (!values.length) return { p50: 0, p95: 0 };
+    return {
+      p50: percentile(values, 50),
+      p95: percentile(values, 95),
+    };
+  }
+
+  pruneReplay(fraction = 0.5) {
+    this.buffer.dropOldest(fraction);
+  }
+
+  async exportState() {
+    const weights = await Promise.all(
+      this.online.getWeights().map(async (tensor) => ({
+        shape: tensor.shape,
+        dtype: tensor.dtype,
+        data: Buffer.from(await tensor.data()).toString('base64'),
+      })),
+    );
+    return {
+      version: 5,
+      kind: 'dqn',
+      stateDim: this.stateDim,
+      actionDim: this.actionDim,
+      config: {
+        gamma: this.gamma,
+        lr: this.lr,
+        batchSize: this.batchSize,
+        bufferSize: this.buffer.capacity,
+        priorityAlpha: this.priorityAlpha,
+        priorityBeta: this.priorityBeta,
+        priorityBetaIncrement: this.priorityBetaIncrement,
+        priorityEps: this.priorityEps,
+        epsStart: this.epsStart,
+        epsEnd: this.epsEnd,
+        epsDecay: this.epsDecay,
+        targetSync: this.targetSync,
+        nStep: this.nStep,
+        dueling: this.dueling,
+        double: this.double,
+        layers: this.layers,
+      },
+      weights,
+    };
+  }
+
+  async importState(state) {
+    if (!state) throw new Error('Invalid state');
+    if (state.stateDim && state.stateDim !== this.stateDim) {
+      throw new Error('State dimension mismatch');
+    }
+    if (state.actionDim && state.actionDim !== this.actionDim) {
+      throw new Error('Action dimension mismatch');
+    }
+    const cfg = state.config ?? {};
+    this.setGamma(cfg.gamma ?? this.gamma);
+    this.setLearningRate(cfg.lr ?? this.lr);
+    this.setBatchSize(cfg.batchSize ?? this.batchSize);
+    this.setBufferSize(cfg.bufferSize ?? this.buffer.capacity);
+    this.setPriorityAlpha(cfg.priorityAlpha ?? this.priorityAlpha);
+    this.setPriorityBeta(cfg.priorityBeta ?? this.priorityBeta);
+    this.setPriorityBetaIncrement(cfg.priorityBetaIncrement ?? this.priorityBetaIncrement);
+    this.setPriorityEps(cfg.priorityEps ?? this.priorityEps);
+    this.setEpsilonSchedule({
+      start: cfg.epsStart ?? this.epsStart,
+      end: cfg.epsEnd ?? this.epsEnd,
+      decay: cfg.epsDecay ?? this.epsDecay,
+    });
+    this.setTargetSync(cfg.targetSync ?? this.targetSync);
+    this.setNStep(cfg.nStep ?? this.nStep);
+    this.dueling = cfg.dueling ?? this.dueling;
+    this.double = cfg.double ?? this.double;
+    this.layers = Array.isArray(cfg.layers) ? cfg.layers.slice() : this.layers;
+    this.online.dispose();
+    this.target.dispose();
+    this.online = this.buildModel();
+    this.target = this.buildModel();
+    if (Array.isArray(state.weights)) {
+      const tensors = state.weights.map((w) =>
+        tf.tensor(Buffer.from(w.data, 'base64'), w.shape, w.dtype),
+      );
+      this.online.setWeights(tensors);
+      this.target.setWeights(tensors);
+      tensors.forEach((t) => t.dispose());
+    }
+    this.syncTarget();
+  }
+
+  getHyperparams() {
+    return {
+      gamma: this.gamma,
+      lr: this.lr,
+      batchSize: this.batchSize,
+      bufferSize: this.buffer.capacity,
+      priorityAlpha: this.priorityAlpha,
+      priorityBeta: this.priorityBeta,
+      priorityBetaIncrement: this.priorityBetaIncrement,
+      priorityEps: this.priorityEps,
+      epsStart: this.epsStart,
+      epsEnd: this.epsEnd,
+      epsDecay: this.epsDecay,
+      targetSync: this.targetSync,
+      nStep: this.nStep,
+      dueling: this.dueling,
+      double: this.double,
+      layers: this.layers.slice(),
+      epsilon: this.epsilon,
+    };
+  }
+}

--- a/src/disk_guard.js
+++ b/src/disk_guard.js
@@ -1,0 +1,142 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { createReadStream, createWriteStream } from 'fs';
+import zlib from 'zlib';
+import {
+  directorySizeMB,
+  ensureDir,
+  listSubdirs,
+  removeDir,
+  safeUnlink,
+} from './utils/fs_utils.js';
+
+const LOG_ROTATE_BYTES = 10 * 1024 * 1024;
+const HEAVY_TASK_COOLDOWN_MS = 30 * 1000;
+
+export class DiskGuard {
+  constructor({
+    saveDir,
+    retainCheckpoints = 5,
+    saveCapMB = 1024,
+    logDir,
+    retainLogs = 3,
+    logCapMB = 200,
+  }) {
+    this.saveDir = saveDir;
+    this.retainCheckpoints = retainCheckpoints;
+    this.saveCapMB = saveCapMB;
+    this.logDir = logDir ?? path.join(saveDir, '..', 'logs');
+    this.retainLogs = retainLogs;
+    this.logCapMB = logCapMB;
+    this._lastPrune = 0;
+    this._lastLogPrune = 0;
+  }
+
+  async init() {
+    await ensureDir(this.saveDir);
+    await ensureDir(this.logDir);
+  }
+
+  async dirSizeMB(target) {
+    return directorySizeMB(target);
+  }
+
+  async _sortCheckpoints() {
+    const entries = await listSubdirs(this.saveDir);
+    const checkpoints = [];
+    for (const entry of entries) {
+      if (['latest', 'best', 'tmp'].includes(entry.name)) continue;
+      const stat = await fs.stat(entry.fullPath);
+      checkpoints.push({ name: entry.name, path: entry.fullPath, mtime: stat.mtimeMs });
+    }
+    checkpoints.sort((a, b) => a.mtime - b.mtime);
+    return checkpoints;
+  }
+
+  async pruneCheckpoints() {
+    const now = Date.now();
+    if (now - this._lastPrune < HEAVY_TASK_COOLDOWN_MS) return;
+    this._lastPrune = now;
+
+    const checkpoints = await this._sortCheckpoints();
+    const toRemove = checkpoints.length - this.retainCheckpoints;
+    if (toRemove > 0) {
+      const victims = checkpoints.slice(0, toRemove);
+      for (const victim of victims) {
+        await removeDir(victim.path);
+      }
+    }
+
+    let size = await directorySizeMB(this.saveDir);
+    if (size <= this.saveCapMB) return;
+    for (const checkpoint of checkpoints) {
+      if (size <= this.saveCapMB) break;
+      await removeDir(checkpoint.path);
+      size = await directorySizeMB(this.saveDir);
+    }
+  }
+
+  async rotateLogs(baseName = 'training_log.jsonl') {
+    const now = Date.now();
+    if (now - this._lastLogPrune < HEAVY_TASK_COOLDOWN_MS) return;
+    this._lastLogPrune = now;
+
+    const logPath = path.join(this.logDir, baseName);
+    let stat;
+    try {
+      stat = await fs.stat(logPath);
+    } catch (err) {
+      if (err.code === 'ENOENT') return;
+      throw err;
+    }
+    if (stat.size < LOG_ROTATE_BYTES) return;
+
+    const entries = await fs.readdir(this.logDir);
+    const gzipped = entries
+      .filter((name) => name.startsWith(baseName.replace('.jsonl', '')) && name.endsWith('.gz'))
+      .sort();
+    const lastIndex = gzipped.length
+      ? parseInt(gzipped[gzipped.length - 1].match(/_(\d+)\.jsonl\.gz$/)?.[1] ?? '0', 10)
+      : 0;
+    const nextIndex = lastIndex + 1;
+    const targetName = `${baseName.replace('.jsonl', '')}_${nextIndex}.jsonl.gz`;
+    const targetPath = path.join(this.logDir, targetName);
+
+    await new Promise((resolve, reject) => {
+      const source = createReadStream(logPath);
+      const gzip = zlib.createGzip();
+      const dest = createWriteStream(targetPath);
+      source.on('error', reject);
+      dest.on('error', reject);
+      dest.on('finish', resolve);
+      source.pipe(gzip).pipe(dest);
+    });
+    await safeUnlink(logPath);
+    await fs.writeFile(logPath, '');
+
+    const updated = await fs.readdir(this.logDir);
+    const gzFiles = updated
+      .filter((name) => name.endsWith('.jsonl.gz'))
+      .map((name) => ({ name, path: path.join(this.logDir, name) }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    if (gzFiles.length > this.retainLogs) {
+      const victims = gzFiles.slice(0, gzFiles.length - this.retainLogs);
+      for (const victim of victims) {
+        await safeUnlink(victim.path);
+      }
+    }
+
+    let totalSize = await directorySizeMB(this.logDir);
+    if (totalSize <= this.logCapMB) return;
+    const remaining = await fs.readdir(this.logDir);
+    const gzSorted = remaining
+      .filter((name) => name.endsWith('.jsonl.gz'))
+      .map((name) => ({ name, path: path.join(this.logDir, name) }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const file of gzSorted) {
+      if (totalSize <= this.logCapMB) break;
+      await safeUnlink(file.path);
+      totalSize = await directorySizeMB(this.logDir);
+    }
+  }
+}

--- a/src/env/snake.js
+++ b/src/env/snake.js
@@ -1,0 +1,332 @@
+import { clamp } from '../utils/ring_buffer.js';
+
+export const REWARD_DEFAULTS = {
+  stepPenalty: 0.01,
+  turnPenalty: 0.001,
+  approachBonus: 0.03,
+  retreatPenalty: 0.03,
+  loopPenalty: 0.5,
+  revisitPenalty: 0.05,
+  wallPenalty: 10,
+  selfPenalty: 25.5,
+  timeoutPenalty: 5,
+  fruitReward: 10,
+  compactWeight: 0,
+  trapPenalty: 0.5,
+  spaceGainBonus: 0.05,
+};
+
+const LOOP_PATTERNS = new Set(['1,2,1,2', '2,1,2,1']);
+
+export class SnakeEnv {
+  constructor(cols = 20, rows = 20, rewardOverrides = {}) {
+    this.cols = cols;
+    this.rows = rows;
+    this.setRewardConfig(rewardOverrides);
+    this.reset();
+  }
+
+  setRewardConfig(overrides = {}) {
+    this.reward = { ...REWARD_DEFAULTS, ...overrides };
+  }
+
+  idx(x, y) {
+    return y * this.cols + x;
+  }
+
+  neighbors(x, y) {
+    return [
+      { x: x + 1, y },
+      { x: x - 1, y },
+      { x, y: y + 1 },
+      { x, y: y - 1 },
+    ].filter((p) => p.x >= 0 && p.y >= 0 && p.x < this.cols && p.y < this.rows);
+  }
+
+  freeSpaceFrom(sx, sy, tailWillMove) {
+    const seen = new Set();
+    const queue = [{ x: sx, y: sy }];
+    const blocked = new Set(this.snakeSet);
+    blocked.delete(`${sx},${sy}`);
+    if (tailWillMove && this.snake.length) {
+      const t = this.snake[this.snake.length - 1];
+      blocked.delete(`${t.x},${t.y}`);
+    }
+    while (queue.length) {
+      const p = queue.pop();
+      const key = `${p.x},${p.y}`;
+      if (seen.has(key)) continue;
+      if (blocked.has(key)) continue;
+      seen.add(key);
+      for (const n of this.neighbors(p.x, p.y)) queue.push(n);
+      if (seen.size > this.cols * this.rows) break;
+    }
+    return seen.size;
+  }
+
+  computeSlack() {
+    if (!this.snake?.length) return 0;
+    let minX = this.snake[0].x;
+    let maxX = this.snake[0].x;
+    let minY = this.snake[0].y;
+    let maxY = this.snake[0].y;
+    for (const seg of this.snake) {
+      if (seg.x < minX) minX = seg.x;
+      if (seg.x > maxX) maxX = seg.x;
+      if (seg.y < minY) minY = seg.y;
+      if (seg.y > maxY) maxY = seg.y;
+    }
+    const width = maxX - minX + 1;
+    const height = maxY - minY + 1;
+    const area = width * height;
+    return Math.max(0, area - this.snake.length);
+  }
+
+  spawnFruit() {
+    const free = [];
+    for (let y = 0; y < this.rows; y++) {
+      for (let x = 0; x < this.cols; x++) {
+        if (!this.snakeSet.has(`${x},${y}`)) free.push({ x, y });
+      }
+    }
+    this.fruit = free.length ? free[(Math.random() * free.length) | 0] : { x: -1, y: -1 };
+  }
+
+  reset() {
+    this.dir = { x: 1, y: 0 };
+    const cx = (this.cols / 2) | 0;
+    const cy = (this.rows / 2) | 0;
+    this.snake = [{ x: cx - 1, y: cy }, { x: cx, y: cy }];
+    this.snakeSet = new Set(this.snake.map((p) => `${p.x},${p.y}`));
+    this.visit = new Float32Array(this.cols * this.rows).fill(0);
+    this.actionHist = [];
+    this.spawnFruit();
+    this.steps = 0;
+    this.stepsSinceFruit = 0;
+    this.alive = true;
+    this.prevSlack = this.computeSlack();
+    this.episodeFruit = 0;
+    this.loopHits = 0;
+    this.revisitAccum = 0;
+    this.timeToFruitAccum = 0;
+    this.timeToFruitCount = 0;
+    this.lastMoveApproach = 0;
+    return this.getState();
+  }
+
+  getVisit(x, y) {
+    if (x < 0 || y < 0 || x >= this.cols || y >= this.rows) return 1;
+    return this.visit[this.idx(x, y)] || 0;
+  }
+
+  turn(action) {
+    const d = this.dir;
+    if (action === 1) this.dir = { x: -d.y, y: d.x };
+    else if (action === 2) this.dir = { x: d.y, y: -d.x };
+  }
+
+  step(action) {
+    if (!this.alive) {
+      return { state: this.getState(), reward: 0, done: true, info: { crash: 'dead' } };
+    }
+    const R = this.reward;
+    this.turn(action);
+    const head = this.snake[0];
+    const nx = head.x + this.dir.x;
+    const ny = head.y + this.dir.y;
+    this.steps++;
+    this.stepsSinceFruit++;
+    const key = `${nx},${ny}`;
+    const tail = this.snake[this.snake.length - 1];
+    const willGrow = nx === this.fruit.x && ny === this.fruit.y;
+    const hitsWall = nx < 0 || ny < 0 || nx >= this.cols || ny >= this.rows;
+    const hitsBody = this.snakeSet.has(key) && !(tail && tail.x === nx && tail.y === ny && !willGrow);
+    if (hitsWall || hitsBody) {
+      this.alive = false;
+      const crashReward = hitsWall ? -R.wallPenalty : -R.selfPenalty;
+      return {
+        state: this.getState(),
+        reward: crashReward,
+        done: true,
+        info: {
+          crash: hitsWall ? 'wall' : 'self',
+          loopPenaltyApplied: false,
+          revisitPenalty: 0,
+          ateFruit: false,
+          timeToFruit: null,
+        },
+      };
+    }
+
+    let spaceReward = 0;
+    if ((R.trapPenalty ?? 0) !== 0 || (R.spaceGainBonus ?? 0) !== 0) {
+      const space = this.freeSpaceFrom(nx, ny, !willGrow);
+      const need = this.snake.length + 2;
+      const denom = Math.max(1, need);
+      if (space < need) {
+        spaceReward -= R.trapPenalty * (1 + (need - space) / denom);
+      } else if (R.spaceGainBonus) {
+        const curSpace = this.freeSpaceFrom(this.snake[0].x, this.snake[0].y, true);
+        if (space > curSpace) {
+          spaceReward += R.spaceGainBonus * Math.min(1, (space - curSpace) / denom);
+        }
+      }
+    }
+
+    for (let i = 0; i < this.visit.length; i++) this.visit[i] *= 0.995;
+
+    this.snake.unshift({ x: nx, y: ny });
+    let reward = -R.stepPenalty;
+    reward += spaceReward;
+    let loopPenaltyApplied = false;
+    if (action !== 0) reward -= R.turnPenalty;
+    this.actionHist.push(action);
+    if (this.actionHist.length > 6) this.actionHist.shift();
+    if (this.actionHist.length >= 4) {
+      const last4 = this.actionHist.slice(-4).join(',');
+      if (LOOP_PATTERNS.has(last4)) {
+        reward -= R.loopPenalty;
+        loopPenaltyApplied = true;
+        this.loopHits++;
+      }
+    }
+
+    const vidx = this.idx(nx, ny);
+    const revisitPenalty = this.visit[vidx] * R.revisitPenalty;
+    reward -= revisitPenalty;
+    this.revisitAccum += revisitPenalty;
+
+    let ateFruit = false;
+    let timeToFruit = null;
+    let approachDelta = 0;
+    if (nx === this.fruit.x && ny === this.fruit.y) {
+      ateFruit = true;
+      reward += R.fruitReward;
+      this.snakeSet.add(`${nx},${ny}`);
+      this.spawnFruit();
+      timeToFruit = this.stepsSinceFruit;
+      this.timeToFruitAccum += this.stepsSinceFruit;
+      this.timeToFruitCount += 1;
+      this.stepsSinceFruit = 0;
+      this.episodeFruit += 1;
+    } else {
+      const tailSegment = this.snake.pop();
+      this.snakeSet.delete(`${tailSegment.x},${tailSegment.y}`);
+      this.snakeSet.add(`${nx},${ny}`);
+      this.visit[vidx] = Math.min(1, this.visit[vidx] + 0.3);
+      const prevDist = Math.abs(head.x - this.fruit.x) + Math.abs(head.y - this.fruit.y);
+      const newDist = Math.abs(nx - this.fruit.x) + Math.abs(ny - this.fruit.y);
+      if (newDist < prevDist) {
+        reward += R.approachBonus;
+        approachDelta = 1;
+      } else if (newDist > prevDist) {
+        reward -= R.retreatPenalty;
+        approachDelta = -1;
+      }
+    }
+
+    const slack = this.computeSlack();
+    const slackDelta = this.prevSlack - slack;
+    if (R.compactWeight !== 0) {
+      reward += slackDelta * R.compactWeight;
+    }
+    this.prevSlack = slack;
+
+    if (this.stepsSinceFruit > this.cols * this.rows * 2) {
+      this.alive = false;
+      reward -= R.timeoutPenalty;
+      return {
+        state: this.getState(),
+        reward,
+        done: true,
+        info: {
+          crash: 'timeout',
+          loopPenaltyApplied,
+          revisitPenalty,
+          ateFruit,
+          timeToFruit,
+          approachDelta,
+        },
+      };
+    }
+
+    return {
+      state: this.getState(),
+      reward,
+      done: false,
+      info: {
+        crash: null,
+        loopPenaltyApplied,
+        revisitPenalty,
+        ateFruit,
+        timeToFruit,
+        approachDelta,
+      },
+    };
+  }
+
+  getState() {
+    const head = this.snake[0];
+    const left = { x: -this.dir.y, y: this.dir.x };
+    const right = { x: this.dir.y, y: -this.dir.x };
+    const block = (dx, dy) => {
+      const x = head.x + dx;
+      const y = head.y + dy;
+      return x < 0 || y < 0 || x >= this.cols || y >= this.rows || this.snakeSet.has(`${x},${y}`) ? 1 : 0;
+    };
+    const danger = [block(this.dir.x, this.dir.y), block(left.x, left.y), block(right.x, right.y)];
+    const dir = [
+      this.dir.y === -1 ? 1 : 0,
+      this.dir.y === 1 ? 1 : 0,
+      this.dir.x === -1 ? 1 : 0,
+      this.dir.x === 1 ? 1 : 0,
+    ];
+    const fruit = [
+      this.fruit.y < head.y ? 1 : 0,
+      this.fruit.y > head.y ? 1 : 0,
+      this.fruit.x < head.x ? 1 : 0,
+      this.fruit.x > head.x ? 1 : 0,
+    ];
+    const dists = [
+      head.y / (this.rows - 1 || 1),
+      (this.rows - 1 - head.y) / (this.rows - 1 || 1),
+      head.x / (this.cols - 1 || 1),
+      (this.cols - 1 - head.x) / (this.cols - 1 || 1),
+    ];
+    const dx = this.fruit.x - head.x;
+    const dy = this.fruit.y - head.y;
+    const len = Math.hypot(dx, dy) || 1;
+    const crowd = [
+      this.getVisit(head.x, head.y - 1),
+      this.getVisit(head.x, head.y + 1),
+      this.getVisit(head.x - 1, head.y),
+      this.getVisit(head.x + 1, head.y),
+    ];
+    return Float32Array.from([
+      ...danger,
+      ...dir,
+      ...fruit,
+      ...dists,
+      dy / len,
+      dx / len,
+      ...crowd,
+    ]);
+  }
+
+  cloneRewardConfig() {
+    return { ...this.reward };
+  }
+}
+
+export function clampRewardConfig(config = {}) {
+  return {
+    ...config,
+    loopPenalty: clamp(config.loopPenalty ?? REWARD_DEFAULTS.loopPenalty, 0, 1),
+    compactWeight: clamp(config.compactWeight ?? REWARD_DEFAULTS.compactWeight, 0, 0.1),
+    revisitPenalty: clamp(config.revisitPenalty ?? REWARD_DEFAULTS.revisitPenalty, 0, 0.1),
+    selfPenalty: clamp(config.selfPenalty ?? REWARD_DEFAULTS.selfPenalty, 0, 30),
+    turnPenalty: clamp(config.turnPenalty ?? REWARD_DEFAULTS.turnPenalty, 0, 0.02),
+    approachBonus: clamp(config.approachBonus ?? REWARD_DEFAULTS.approachBonus, 0, 0.1),
+    retreatPenalty: clamp(config.retreatPenalty ?? REWARD_DEFAULTS.retreatPenalty, 0, 0.1),
+  };
+}

--- a/src/env/vec_env.js
+++ b/src/env/vec_env.js
@@ -1,0 +1,55 @@
+import { SnakeEnv } from './snake.js';
+
+export class VecSnakeEnv {
+  constructor(envCount = 1, { cols = 20, rows = 20, rewardConfig = {} } = {}) {
+    this.envCount = Math.max(1, envCount | 0);
+    this.cols = cols;
+    this.rows = rows;
+    this.rewardConfig = { ...rewardConfig };
+    this.envs = Array.from({ length: this.envCount }, () => new SnakeEnv(cols, rows, rewardConfig));
+  }
+
+  setRewardConfig(config) {
+    this.rewardConfig = { ...config };
+    for (const env of this.envs) env.setRewardConfig(config);
+  }
+
+  setBoardSize(cols, rows) {
+    this.cols = cols;
+    this.rows = rows;
+    this.envs = Array.from({ length: this.envCount }, () => new SnakeEnv(cols, rows, this.rewardConfig));
+  }
+
+  reset() {
+    return this.envs.map((env) => env.reset());
+  }
+
+  resetEnv(index) {
+    const env = this.envs[index];
+    if (!env) throw new Error(`Env index ${index} out of range`);
+    return env.reset();
+  }
+
+  step(actions) {
+    if (!Array.isArray(actions) || actions.length !== this.envCount) {
+      throw new Error(`Expected actions array length ${this.envCount}`);
+    }
+    const results = this.envs.map((env, i) => env.step(actions[i] ?? 0));
+    return {
+      nextStates: results.map((r) => r.state),
+      rewards: results.map((r) => r.reward),
+      dones: results.map((r) => r.done),
+      infos: results.map((r) => r.info ?? {}),
+    };
+  }
+
+  getStateDim() {
+    const env = this.envs[0] ?? new SnakeEnv(this.cols, this.rows, this.rewardConfig);
+    const state = env.getState();
+    return state.length;
+  }
+
+  getActionDim() {
+    return 3; // forward, left, right
+  }
+}

--- a/src/replay/n_step.js
+++ b/src/replay/n_step.js
@@ -1,0 +1,64 @@
+export class NStepAccumulator {
+  constructor(n = 1, gamma = 0.99) {
+    this.setConfig(n, gamma);
+  }
+
+  setConfig(n, gamma) {
+    this.n = Math.max(1, n | 0);
+    this.gamma = gamma;
+    this.queue = [];
+  }
+
+  push(step) {
+    const item = {
+      s: Float32Array.from(step.s),
+      a: step.a | 0,
+      r: +step.r,
+      ns: Float32Array.from(step.ns),
+      d: !!step.d,
+    };
+    this.queue.push(item);
+    const ready = [];
+    while (this.queue.length >= this.n) {
+      ready.push(this.build());
+      this.queue.shift();
+      if (ready[ready.length - 1].d) {
+        this.queue.length = 0;
+        return ready;
+      }
+    }
+    if (item.d) {
+      ready.push(...this.flush());
+    }
+    return ready;
+  }
+
+  build() {
+    let reward = 0;
+    let discount = 1;
+    let done = false;
+    let nextState = this.queue[0].ns;
+    const limit = Math.min(this.n, this.queue.length);
+    for (let i = 0; i < limit; i++) {
+      const step = this.queue[i];
+      reward += discount * step.r;
+      discount *= this.gamma;
+      nextState = step.ns;
+      if (step.d) {
+        done = true;
+        break;
+      }
+    }
+    const first = this.queue[0];
+    return { s: first.s, a: first.a, r: reward, ns: nextState, d: done };
+  }
+
+  flush() {
+    const out = [];
+    while (this.queue.length) {
+      out.push(this.build());
+      this.queue.shift();
+    }
+    return out;
+  }
+}

--- a/src/replay/prioritized_buffer.js
+++ b/src/replay/prioritized_buffer.js
@@ -1,0 +1,141 @@
+export class PrioritizedReplayBuffer {
+  constructor(capacity = 50000, opts = {}) {
+    this.capacity = Math.max(1, capacity | 0);
+    this.buffer = [];
+    this.position = 0;
+    this.alpha = opts.alpha ?? 0.6;
+    this.beta = opts.beta ?? 0.4;
+    this.betaIncrement = opts.betaIncrement ?? 0.000002;
+    this.priorityEps = opts.priorityEps ?? 0.001;
+    this.priorities = new Float32Array(this.capacity);
+    this.maxPriority = this.priorityEps;
+  }
+
+  size() {
+    return this.buffer.length;
+  }
+
+  setCapacity(cap) {
+    const newCap = Math.max(1, cap | 0);
+    if (newCap === this.capacity) return;
+    this.capacity = newCap;
+    if (this.buffer.length > this.capacity) {
+      this.buffer = this.buffer.slice(-this.capacity);
+    }
+    this.position = Math.min(this.position, this.capacity - 1);
+    this.priorities = new Float32Array(this.capacity);
+    this.maxPriority = this.priorityEps;
+  }
+
+  setAlpha(val) {
+    this.alpha = Math.max(0.01, +val || 0.01);
+  }
+
+  setBeta(val) {
+    this.beta = Math.min(1, Math.max(0, +val || 0));
+  }
+
+  setBetaIncrement(val) {
+    this.betaIncrement = Math.max(0, +val || 0);
+  }
+
+  setPriorityEps(val) {
+    this.priorityEps = Math.max(1e-6, +val || 1e-6);
+  }
+
+  push(sample) {
+    const entry = {
+      s: Float32Array.from(sample.s),
+      a: sample.a | 0,
+      r: +sample.r,
+      ns: Float32Array.from(sample.ns),
+      d: !!sample.d,
+      w: sample.w ?? 1,
+    };
+    if (this.buffer.length < this.capacity) {
+      this.buffer.push(entry);
+      const idx = this.buffer.length - 1;
+      this.priorities[idx] = this.maxPriority;
+    } else {
+      const idx = this.position % this.capacity;
+      this.buffer[idx] = entry;
+      this.priorities[idx] = this.maxPriority;
+    }
+    this.position = (this.position + 1) % this.capacity;
+  }
+
+  sample(batchSize) {
+    if (!this.buffer.length) return null;
+    const size = Math.min(batchSize, this.buffer.length);
+    const priorities = this.priorities.slice(0, this.buffer.length);
+    const probs = priorities.map((p) => Math.pow(p || this.priorityEps, this.alpha));
+    const sum = probs.reduce((a, b) => a + b, 0) || 1;
+    const normalized = probs.map((p) => p / sum);
+    const batch = [];
+    const indices = [];
+    const weights = [];
+    const beta = this.beta;
+    this.beta = Math.min(1, this.beta + this.betaIncrement);
+    const maxWeight = Math.pow(this.buffer.length * Math.min(...normalized), -beta);
+    for (let i = 0; i < size; i++) {
+      const r = Math.random();
+      let acc = 0;
+      let index = 0;
+      for (let j = 0; j < normalized.length; j++) {
+        acc += normalized[j];
+        if (r <= acc) {
+          index = j;
+          break;
+        }
+      }
+      batch.push(this.buffer[index]);
+      indices.push(index);
+      const w = Math.pow(this.buffer.length * normalized[index], -beta);
+      weights.push(w / (maxWeight || 1));
+    }
+    return { batch, indices, weights };
+  }
+
+  updatePriorities(indices, priorities) {
+    indices.forEach((idx, i) => {
+      const priority = Math.max(this.priorityEps, priorities[i]);
+      this.priorities[idx] = priority;
+      this.maxPriority = Math.max(this.maxPriority, priority);
+    });
+  }
+
+  dropOldest(fraction = 0.5) {
+    const removeCount = Math.floor(this.buffer.length * clampFraction(fraction));
+    if (removeCount <= 0) return;
+    this.buffer = this.buffer.slice(removeCount);
+    this.priorities = new Float32Array(this.capacity);
+    this.maxPriority = this.priorityEps;
+    this.position = this.buffer.length % this.capacity;
+  }
+
+  toJSON() {
+    return {
+      cap: this.capacity,
+      buf: this.buffer.map((item) => ({
+        s: Array.from(item.s),
+        a: item.a,
+        r: item.r,
+        ns: Array.from(item.ns),
+        d: item.d,
+        w: item.w,
+      })),
+      pos: this.position,
+      alpha: this.alpha,
+      beta: this.beta,
+      betaIncrement: this.betaIncrement,
+      priorityEps: this.priorityEps,
+      priorities: Array.from(this.priorities),
+      maxPriority: this.maxPriority,
+    };
+  }
+}
+
+function clampFraction(value) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(value, 0), 1);
+}

--- a/src/training/auto_scheduler.js
+++ b/src/training/auto_scheduler.js
@@ -1,0 +1,263 @@
+import { clamp } from '../utils/ring_buffer.js';
+import { MetricsCollector } from './metrics_collector.js';
+
+const EPS_END_MIN = 0.01;
+const EPS_END_MAX = 0.3;
+const EPS_DECAY_MIN = 5000;
+const EPS_DECAY_MAX = 200000;
+const GAMMA_MIN = 0.9;
+const GAMMA_MAX = 0.999;
+const LR_MIN = 2e-4;
+const LR_MAX = 5e-4;
+const NSTEP_MIN = 1;
+const NSTEP_MAX = 5;
+const ADJUST_COOLDOWN_EPISODES = 500;
+const EVAL_INTERVAL_EPISODES = 2000;
+const ROLLBACK_WINDOW_EPISODES = 5000;
+
+export class AutoScheduler {
+  constructor({
+    initialConfig,
+    rewardConfig,
+    minSaveCooldownMinutes = 10,
+    cosineCycleEpisodes = 200000,
+  }) {
+    this.metrics = new MetricsCollector();
+    this.baseEpsEnd = initialConfig.epsEnd;
+    this.baseEpsDecay = initialConfig.epsDecay;
+    this.baseGamma = initialConfig.gamma ?? 0.98;
+    this.currentEpsEnd = initialConfig.epsEnd;
+    this.currentEpsDecay = initialConfig.epsDecay;
+    this.epsilonBoost = null;
+
+    this.lrScale = 1;
+    this.cosineCycle = cosineCycleEpisodes;
+    this.lastLRAdjustEpisode = 0;
+
+    this.lastAdjustEpisode = new Map();
+    this.lastEvalEpisode = 0;
+    this.lastEvalTime = 0;
+    this.lastCheckpointTime = 0;
+    this.minSaveCooldownMs = minSaveCooldownMinutes * 60 * 1000;
+
+    this.rewardConfig = { ...rewardConfig };
+    this.boardStages = [
+      { size: 10, threshold: 0 },
+      { size: 14, threshold: 60 },
+      { size: 18, threshold: 120 },
+      { size: 20, threshold: 200 },
+    ];
+    this.boardIndex = 0;
+    this.lastBoardChangeEpisode = 0;
+
+    this.tdMeanHistory = [];
+    this.bestEval = null;
+    this.bestEvalEpisode = 0;
+  }
+
+  observe(summary, tdStats, episode) {
+    this.metrics.recordLoss(summary.tdLossMean ?? 0);
+    this.tdMeanHistory.push(summary.tdLossMean ?? 0);
+    if (this.tdMeanHistory.length > 10) this.tdMeanHistory.shift();
+  }
+
+  getMetrics() {
+    return this.metrics.getSummary();
+  }
+
+  recordEpisode(data) {
+    const record = this.metrics.toEpisodeRecord(data);
+    this.metrics.recordEpisode(record);
+  }
+
+  maybeAdvanceBoard(episode) {
+    const summary = this.metrics.getSummary();
+    const nextStage = this.boardStages[this.boardIndex + 1];
+    if (!nextStage) return null;
+    if (summary.maFruit500 > nextStage.threshold) {
+      this.boardIndex += 1;
+      this.lastBoardChangeEpisode = episode;
+      return this.boardStages[this.boardIndex].size;
+    }
+    return null;
+  }
+
+  shouldCheckpoint(now) {
+    if (now - this.lastCheckpointTime < this.minSaveCooldownMs) return false;
+    this.lastCheckpointTime = now;
+    return true;
+  }
+
+  maybeEval(episode) {
+    return episode - this.lastEvalEpisode >= EVAL_INTERVAL_EPISODES;
+  }
+
+  registerEval(episode) {
+    this.lastEvalEpisode = episode;
+    this.lastEvalTime = Date.now();
+  }
+
+  updateBestEval(episode, fruits, meta) {
+    if (!this.bestEval || fruits >= this.bestEval.fruits + 5 || (fruits >= this.bestEval.fruits * 1.02)) {
+      this.bestEval = { episode, fruits, meta };
+      this.bestEvalEpisode = episode;
+      return true;
+    }
+    return false;
+  }
+
+  needsRollback(metrics, episode) {
+    if (!this.bestEval) return false;
+    if (episode - this.bestEvalEpisode < ROLLBACK_WINDOW_EPISODES) return false;
+    const threshold = this.bestEval.fruits * 0.75;
+    return metrics.maFruit100 < threshold;
+  }
+
+  _canAdjust(key, episode) {
+    const last = this.lastAdjustEpisode.get(key) ?? -Infinity;
+    if (episode - last < ADJUST_COOLDOWN_EPISODES) return false;
+    this.lastAdjustEpisode.set(key, episode);
+    return true;
+  }
+
+  tuneHyperparams(agent, rewardConfig, metrics, tdStats, episode) {
+    const adjustments = [];
+    this._applyCosineLR(agent, episode, adjustments);
+    this._adjustEpsilon(agent, metrics, episode, adjustments);
+    this._adjustLR(agent, metrics, adjustments, episode);
+    this._adjustNStep(agent, metrics, episode, adjustments);
+    this._adjustGamma(agent, metrics, episode, adjustments);
+    this._annealPER(agent, tdStats, episode, adjustments);
+    this._adjustRewards(agent, rewardConfig, metrics, episode, adjustments);
+    return adjustments;
+  }
+
+  _applyCosineLR(agent, episode, adjustments) {
+    if (!this.cosineCycle) return;
+    const cyclePos = (episode % this.cosineCycle) / this.cosineCycle;
+    const base = LR_MIN + 0.5 * (LR_MAX - LR_MIN) * (1 + Math.cos(Math.PI * cyclePos));
+    const lr = clamp(base * this.lrScale, LR_MIN, LR_MAX);
+    if (Math.abs(lr - agent.lr) / agent.lr > 0.05) {
+      agent.setLearningRate(lr);
+      adjustments.push({ type: 'lr', value: lr, reason: 'cosine' });
+    }
+  }
+
+  _adjustLR(agent, metrics, adjustments, episode) {
+    if (this.tdMeanHistory.length < 4) return;
+    const last = this.tdMeanHistory.slice(-3);
+    const increasing = last[0] < last[1] && last[1] < last[2];
+    const ratio = metrics.tdLossMean ? metrics.tdLossStd / metrics.tdLossMean : 0;
+    if ((increasing || ratio > 0.8) && this._canAdjust('lr-decay', episode)) {
+      this.lrScale = Math.max(0.2, this.lrScale * 0.8);
+      const lr = clamp(agent.lr * 0.8, LR_MIN, LR_MAX);
+      agent.setLearningRate(lr);
+      adjustments.push({ type: 'lr', value: lr, reason: 'reduce_plateau' });
+      this.lastLRAdjustEpisode = episode;
+    } else if (metrics.fruitSlope > 0 && this.lrScale < 1 && this._canAdjust('lr-recover', episode)) {
+      this.lrScale = Math.min(1, this.lrScale * 1.05);
+      const lr = clamp(agent.lr * 1.05, LR_MIN, LR_MAX);
+      agent.setLearningRate(lr);
+      adjustments.push({ type: 'lr', value: lr, reason: 'recover' });
+    }
+  }
+
+  _adjustEpsilon(agent, metrics, episode, adjustments) {
+    const improvement = this.metrics.getFruitImprovement(2000);
+    const slope = metrics.fruitSlope ?? 0;
+    if (slope <= 0 && improvement < 2 && this._canAdjust('epsilon-boost', episode)) {
+      const newEnd = clamp(agent.epsEnd + 0.03, EPS_END_MIN, EPS_END_MAX);
+      const newDecay = clamp(agent.epsDecay * 1.2, EPS_DECAY_MIN, EPS_DECAY_MAX);
+      agent.setEpsilonSchedule({ end: newEnd, decay: newDecay });
+      this.currentEpsEnd = newEnd;
+      this.currentEpsDecay = newDecay;
+      adjustments.push({ type: 'epsilon', end: newEnd, decay: newDecay, reason: 'stagnation' });
+    }
+    if (improvement < -5 && this._canAdjust('epsilon-regress', episode)) {
+      const newEnd = clamp(agent.epsEnd + 0.02, EPS_END_MIN, EPS_END_MAX);
+      agent.setEpsilonSchedule({ end: newEnd });
+      this.currentEpsEnd = newEnd;
+      this.lrScale = Math.max(0.2, this.lrScale * 0.9);
+      adjustments.push({ type: 'epsilon', end: newEnd, reason: 'regression' });
+    }
+    if (this.currentEpsEnd > this.baseEpsEnd && improvement > 0 && slope > 0 && this._canAdjust('epsilon-revert', episode)) {
+      const stepBack = Math.max(0.01, (this.currentEpsEnd - this.baseEpsEnd) * 0.5);
+      const newEnd = clamp(this.currentEpsEnd - stepBack, EPS_END_MIN, this.baseEpsEnd);
+      const newDecay = clamp(this.currentEpsDecay * 0.9, EPS_DECAY_MIN, this.baseEpsDecay);
+      agent.setEpsilonSchedule({ end: newEnd, decay: newDecay });
+      this.currentEpsEnd = newEnd;
+      this.currentEpsDecay = newDecay;
+      adjustments.push({ type: 'epsilon', end: newEnd, decay: newDecay, reason: 'revert' });
+    }
+  }
+
+  _adjustNStep(agent, metrics, episode, adjustments) {
+    if (metrics.timeToFruitAvg > 250 && agent.nStep < NSTEP_MAX && this._canAdjust('nstep-inc', episode)) {
+      const newN = Math.min(NSTEP_MAX, agent.nStep + 1);
+      agent.setNStep(newN);
+      adjustments.push({ type: 'nStep', value: newN, reason: 'slow_fruit' });
+    } else if (metrics.timeToFruitAvg < 120 && agent.nStep > NSTEP_MIN && this._canAdjust('nstep-dec', episode)) {
+      const newN = Math.max(NSTEP_MIN, agent.nStep - 1);
+      agent.setNStep(newN);
+      adjustments.push({ type: 'nStep', value: newN, reason: 'fast_fruit' });
+    }
+  }
+
+  _adjustGamma(agent, metrics, episode, adjustments) {
+    if (!this.prevAvgLen) this.prevAvgLen = metrics.avgEpisodeLen100;
+    const lenIncrease = metrics.avgEpisodeLen100 > this.prevAvgLen * 1.1;
+    if (lenIncrease && agent.gamma < GAMMA_MAX && this._canAdjust('gamma-inc', episode)) {
+      const newGamma = clamp(agent.gamma + 0.005, GAMMA_MIN, GAMMA_MAX);
+      agent.setGamma(newGamma);
+      adjustments.push({ type: 'gamma', value: newGamma, reason: 'longer_episodes' });
+    }
+    if (metrics.crashRateSelf > 0.5 && agent.gamma > this.baseGamma && this._canAdjust('gamma-dec', episode)) {
+      const newGamma = clamp(agent.gamma - 0.005, GAMMA_MIN, GAMMA_MAX);
+      agent.setGamma(newGamma);
+      adjustments.push({ type: 'gamma', value: newGamma, reason: 'self_crash' });
+    }
+    this.prevAvgLen = metrics.avgEpisodeLen100;
+  }
+
+  _annealPER(agent, tdStats, episode, adjustments) {
+    const beta = clamp(agent.priorityBeta + 0.0005, agent.priorityBeta, 1);
+    if (beta !== agent.priorityBeta) {
+      agent.setPriorityBeta(beta);
+      adjustments.push({ type: 'per', beta, reason: 'anneal_beta' });
+    }
+    const ratio = tdStats?.p50 ? tdStats.p95 / (tdStats.p50 || 1) : 1;
+    if (ratio > 1.6 && this._canAdjust('per-alpha-inc', episode)) {
+      const alpha = clamp(agent.priorityAlpha + 0.05, 0.1, 1);
+      agent.setPriorityAlpha(alpha);
+      adjustments.push({ type: 'per', alpha, reason: 'heavy_tail' });
+    } else if (ratio < 1.2 && this._canAdjust('per-alpha-dec', episode)) {
+      const alpha = clamp(agent.priorityAlpha - 0.05, 0.1, 1);
+      agent.setPriorityAlpha(alpha);
+      adjustments.push({ type: 'per', alpha, reason: 'light_tail' });
+    }
+  }
+
+  _adjustRewards(agent, rewardConfig, metrics, episode, adjustments) {
+    if (metrics.loopHitRate > 0.01 && metrics.fruitSlope <= 0 && this._canAdjust('reward-loop', episode)) {
+      rewardConfig.loopPenalty = clamp((rewardConfig.loopPenalty ?? 0.5) + 0.05, 0, 1);
+      rewardConfig.compactWeight = 0;
+      adjustments.push({ type: 'reward', key: 'loopPenalty', value: rewardConfig.loopPenalty });
+    }
+    if (metrics.revisitRate > 0.01 && this._canAdjust('reward-revisit', episode)) {
+      rewardConfig.revisitPenalty = clamp((rewardConfig.revisitPenalty ?? 0.05) + 0.005, 0, 0.1);
+      const newEnd = clamp(agent.epsEnd + 0.02, EPS_END_MIN, EPS_END_MAX);
+      agent.setEpsilonSchedule({ end: newEnd });
+      adjustments.push({ type: 'reward', key: 'revisitPenalty', value: rewardConfig.revisitPenalty });
+    }
+    if (metrics.crashRateSelf > 0.4 && this._canAdjust('reward-self', episode)) {
+      rewardConfig.selfPenalty = clamp((rewardConfig.selfPenalty ?? 25.5) + 1, 0, 30);
+      rewardConfig.turnPenalty = clamp((rewardConfig.turnPenalty ?? 0.001) - 0.0002, 0, 0.02);
+      adjustments.push({ type: 'reward', key: 'selfPenalty', value: rewardConfig.selfPenalty });
+    }
+    if (metrics.timeToFruitAvg > 200 && metrics.loopHitRate < 0.005 && metrics.revisitRate < 0.005 && this._canAdjust('reward-fruit', episode)) {
+      rewardConfig.approachBonus = clamp((rewardConfig.approachBonus ?? 0.03) + 0.005, 0, 0.1);
+      rewardConfig.retreatPenalty = clamp((rewardConfig.retreatPenalty ?? 0.03) + 0.005, 0, 0.1);
+      adjustments.push({ type: 'reward', key: 'approachBonus', value: rewardConfig.approachBonus });
+    }
+  }
+}

--- a/src/training/checkpoint_manager.js
+++ b/src/training/checkpoint_manager.js
@@ -1,0 +1,48 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { ensureDir, removeDir, withTempDir, nowISO, writeJsonWithFsync } from '../utils/fs_utils.js';
+
+export class CheckpointManager {
+  constructor({ saveDir, diskGuard, retain = 5 }) {
+    this.saveDir = saveDir;
+    this.diskGuard = diskGuard;
+    this.retain = retain;
+  }
+
+  async init() {
+    await ensureDir(this.saveDir);
+  }
+
+  async save({ agentState, rewardConfig, meta, isBest = false, reason }) {
+    const timestamp = nowISO();
+    const targetDir = path.join(this.saveDir, timestamp);
+    await withTempDir(this.saveDir, async (tempDir) => {
+      const payload = {
+        createdAt: new Date().toISOString(),
+        agent: agentState,
+        rewardConfig,
+        meta,
+        reason,
+        version: 1,
+      };
+      await writeJsonWithFsync(path.join(tempDir, 'checkpoint.json'), payload);
+      await fs.rename(tempDir, targetDir);
+    });
+    await this._updatePointer('latest', targetDir);
+    if (isBest) {
+      await this._updatePointer('best', targetDir);
+    }
+    await this.diskGuard.pruneCheckpoints();
+    return targetDir;
+  }
+
+  async _updatePointer(name, targetDir) {
+    const pointerDir = path.join(this.saveDir, name);
+    const tempPointer = path.join(this.saveDir, `${name}_tmp`);
+    await removeDir(tempPointer);
+    await ensureDir(tempPointer);
+    await fs.cp(targetDir, tempPointer, { recursive: true, force: true });
+    await removeDir(pointerDir);
+    await fs.rename(tempPointer, pointerDir);
+  }
+}

--- a/src/training/logger.js
+++ b/src/training/logger.js
@@ -1,0 +1,69 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { ensureDir } from '../utils/fs_utils.js';
+
+export class TrainingLogger {
+  constructor({ logDir, consoleInterval = 200, logInterval = 500, diskGuard }) {
+    this.logDir = logDir;
+    this.consoleInterval = consoleInterval;
+    this.logInterval = logInterval;
+    this.diskGuard = diskGuard;
+    this.lastConsoleEpisode = 0;
+    this.lastLogEpisode = 0;
+    this.logFile = path.join(this.logDir, 'training_log.jsonl');
+  }
+
+  async init() {
+    await ensureDir(this.logDir);
+  }
+
+  maybeLogConsole({ episode, metrics, agent }) {
+    if (episode - this.lastConsoleEpisode < this.consoleInterval) return;
+    this.lastConsoleEpisode = episode;
+    const msg = [
+      `ep=${episode}`,
+      `maFruit100=${metrics.maFruit100.toFixed(2)}`,
+      `maFruit500=${metrics.maFruit500.toFixed(2)}`,
+      `maReward100=${metrics.maReward100.toFixed(2)}`,
+      `eps=${agent.epsilon?.toFixed(3)}`,
+      `gamma=${agent.gamma?.toFixed(3)}`,
+      `lr=${agent.lr?.toExponential(3)}`,
+    ].join(' | ');
+    console.log(`[TRAIN] ${msg}`);
+  }
+
+  async maybeLogJson({ episode, metrics, agent, adjustments = [], extra = {} }) {
+    if (episode - this.lastLogEpisode < this.logInterval) return;
+    this.lastLogEpisode = episode;
+    const entry = {
+      type: 'metrics',
+      ts: new Date().toISOString(),
+      episode,
+      metrics,
+      agent: {
+        epsilon: agent.epsilon,
+        gamma: agent.gamma,
+        lr: agent.lr,
+        batchSize: agent.batchSize,
+        bufferSize: agent.buffer?.capacity,
+        nStep: agent.nStep,
+      },
+      adjustments,
+      ...extra,
+    };
+    await fs.appendFile(this.logFile, `${JSON.stringify(entry)}\n`);
+    await this.diskGuard.rotateLogs('training_log.jsonl');
+  }
+
+  async logEval({ episode, fruitsAvg, fruitsPerEpisode }) {
+    const entry = {
+      type: 'eval',
+      ts: new Date().toISOString(),
+      episode,
+      fruitsAvg,
+      fruitsPerEpisode,
+    };
+    await fs.appendFile(this.logFile, `${JSON.stringify(entry)}\n`);
+    await this.diskGuard.rotateLogs('training_log.jsonl');
+  }
+}

--- a/src/training/metrics_collector.js
+++ b/src/training/metrics_collector.js
@@ -1,0 +1,132 @@
+import { RingBuffer, mean, std, linearRegressionSlope } from '../utils/ring_buffer.js';
+
+export class MetricsCollector {
+  constructor() {
+    this.episodes = 0;
+    this.steps = 0;
+    this.window100 = [];
+    this.window500 = [];
+    this.lossBuffer = new RingBuffer(2000);
+    this.maFruitHistory = new RingBuffer(200);
+    this.lastEpisodeAt = Date.now();
+    this.bestEval = null;
+    this.bestEvalEpisode = 0;
+  }
+
+  recordEpisode(data) {
+    this.episodes += 1;
+    this.steps += data.length || 0;
+    this.window500.push(data);
+    if (this.window500.length > 500) this.window500.shift();
+    this.window100.push(data);
+    if (this.window100.length > 100) this.window100.shift();
+
+    const ma100 = this.average(this.window100, 'fruits');
+    this.maFruitHistory.push(ma100);
+    this.lastEpisodeAt = Date.now();
+  }
+
+  recordLoss(loss) {
+    if (Number.isFinite(loss)) {
+      this.lossBuffer.push(loss);
+    }
+  }
+
+  average(list, key) {
+    if (!list.length) return 0;
+    return list.reduce((sum, item) => sum + (+item[key] || 0), 0) / list.length;
+  }
+
+  sum(list, key) {
+    if (!list.length) return 0;
+    return list.reduce((sum, item) => sum + (+item[key] || 0), 0);
+  }
+
+  crashRate(list, type) {
+    if (!list.length) return 0;
+    const crashes = list.filter((item) => item.crash === type).length;
+    return crashes / list.length;
+  }
+
+  getSummary() {
+    const maFruit100 = this.average(this.window100, 'fruits');
+    const maFruit500 = this.average(this.window500, 'fruits');
+    const maReward100 = this.average(this.window100, 'reward');
+    const maReward500 = this.average(this.window500, 'reward');
+    const avgEpisodeLen100 = this.average(this.window100, 'length');
+    const crashWall = this.crashRate(this.window500, 'wall');
+    const crashSelf = this.crashRate(this.window500, 'self');
+    const loopHits = this.sum(this.window500, 'loopHits');
+    const totalSteps = this.sum(this.window500, 'length') || 1;
+    const revisitPenalty = this.sum(this.window500, 'revisitPenalty');
+    const timeToFruitSum = this.sum(this.window500, 'timeToFruitTotal');
+    const timeToFruitCount = this.sum(this.window500, 'timeToFruitCount') || 0;
+
+    const lossValues = this.lossBuffer.toArray();
+    const tdLossMean = mean(lossValues);
+    const tdLossStd = std(lossValues);
+
+    const slope = linearRegressionSlope(this.maFruitHistory.toArray().slice(-30));
+
+    return {
+      episodes: this.episodes,
+      steps: this.steps,
+      maFruit100,
+      maFruit500,
+      maReward100,
+      maReward500,
+      avgEpisodeLen100,
+      crashRateWall: crashWall,
+      crashRateSelf: crashSelf,
+      loopHitRate: loopHits / totalSteps,
+      revisitRate: revisitPenalty / totalSteps,
+      timeToFruitAvg: timeToFruitCount ? timeToFruitSum / timeToFruitCount : 0,
+      tdLossMean,
+      tdLossStd,
+      fruitSlope: slope,
+    };
+  }
+
+  getFruitSlope(windowEpisodes = 2000) {
+    const history = this.maFruitHistory.toArray();
+    if (!history.length) return 0;
+    const slice = history.slice(-Math.min(history.length, Math.max(10, Math.floor(windowEpisodes / 50))));
+    return linearRegressionSlope(slice);
+  }
+
+  getFruitImprovement(windowEpisodes = 2000) {
+    const history = this.maFruitHistory.toArray();
+    if (history.length < 2) return 0;
+    const windowSize = Math.max(1, Math.min(history.length, Math.floor(windowEpisodes / 50)));
+    const recent = history.slice(-windowSize);
+    const past = history.slice(-2 * windowSize, -windowSize);
+    if (!past.length) return 0;
+    const recentAvg = recent.reduce((a, b) => a + b, 0) / recent.length;
+    const pastAvg = past.reduce((a, b) => a + b, 0) / past.length;
+    return recentAvg - pastAvg;
+  }
+
+  updateBestEval(episode, fruits, meta) {
+    if (!this.bestEval || fruits > this.bestEval.fruits) {
+      this.bestEval = { episode, fruits, meta };
+      this.bestEvalEpisode = episode;
+      return true;
+    }
+    return false;
+  }
+
+  toEpisodeRecord({ reward, fruits, length, crash, loopHits, revisitPenalty, timeToFruitSamples }) {
+    const count = timeToFruitSamples?.length || 0;
+    const total = count ? timeToFruitSamples.reduce((a, b) => a + b, 0) : 0;
+    return {
+      reward: reward ?? 0,
+      fruits: fruits ?? 0,
+      length: length ?? 0,
+      crash: crash ?? null,
+      loopHits: loopHits ?? 0,
+      revisitPenalty: revisitPenalty ?? 0,
+      timeToFruitTotal: total,
+      timeToFruitCount: count,
+    };
+  }
+}

--- a/src/training/run_training.js
+++ b/src/training/run_training.js
@@ -1,0 +1,382 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { VecSnakeEnv } from '../env/vec_env.js';
+import { SnakeEnv, REWARD_DEFAULTS, clampRewardConfig } from '../env/snake.js';
+import { DQNAgent } from '../agents/dqn_agent.js';
+import { DiskGuard } from '../disk_guard.js';
+import { AutoScheduler } from './auto_scheduler.js';
+import { CheckpointManager } from './checkpoint_manager.js';
+import { TrainingLogger } from './logger.js';
+import { MetricsCollector } from './metrics_collector.js';
+import { ensureDir } from '../utils/fs_utils.js';
+
+function createEpisodeContext(state) {
+  return {
+    state,
+    totalReward: 0,
+    fruits: 0,
+    steps: 0,
+    crash: null,
+    loopHits: 0,
+    revisitPenalty: 0,
+    timeToFruit: [],
+  };
+}
+
+async function runEvaluation(agent, boardSize, rewardConfig, episodes = 5) {
+  const env = new SnakeEnv(boardSize, boardSize, rewardConfig);
+  const perEpisode = [];
+  for (let i = 0; i < episodes; i += 1) {
+    let state = env.reset();
+    let done = false;
+    let steps = 0;
+    let fruits = 0;
+    const maxSteps = boardSize * boardSize * 6;
+    while (!done && steps < maxSteps) {
+      let action = agent.greedyAction(state);
+      const result = env.step(action);
+      state = result.state;
+      done = result.done;
+      if (result.info?.ateFruit) fruits += 1;
+      steps += 1;
+    }
+    perEpisode.push(fruits);
+  }
+  const fruitsAvg = perEpisode.reduce((a, b) => a + b, 0) / perEpisode.length;
+  return { fruitsAvg, perEpisode };
+}
+
+async function loadCheckpoint(agent, rewardConfig, env, dir) {
+  const file = path.join(dir, 'checkpoint.json');
+  const text = await fs.readFile(file, 'utf-8');
+  const data = JSON.parse(text);
+  await agent.importState(data.agent);
+  Object.assign(rewardConfig, data.rewardConfig ?? {});
+  env.setRewardConfig(rewardConfig);
+  return data.meta ?? {};
+}
+
+export async function runTraining(options) {
+  const {
+    mode,
+    envCount,
+    saveDir,
+    checkpointIntervalEpisodes,
+    checkpointIntervalMinutes,
+    retainCheckpoints,
+    saveCapMB,
+    logCapMB,
+    retainLogs,
+    logIntervalEpisodes,
+    consoleIntervalEpisodes,
+    minSaveCooldownMinutes,
+    batchSize,
+    bufferSize,
+    epsilon,
+    gamma,
+    learningRate,
+    nStep,
+    targetSync,
+    priorityAlpha,
+    priorityBeta,
+    priorityBetaIncrement,
+    rewardOverrides = {},
+    manualBoardSize = 20,
+  } = options;
+
+  await ensureDir(saveDir);
+  const diskGuard = new DiskGuard({
+    saveDir,
+    retainCheckpoints,
+    saveCapMB,
+    logCapMB,
+    retainLogs,
+  });
+  await diskGuard.init();
+
+  const logDir = path.join(saveDir, 'logs');
+  const logger = new TrainingLogger({
+    logDir,
+    consoleInterval: consoleIntervalEpisodes,
+    logInterval: logIntervalEpisodes,
+    diskGuard,
+  });
+  await logger.init();
+
+  const checkpointManager = new CheckpointManager({ saveDir, diskGuard, retain: retainCheckpoints });
+  await checkpointManager.init();
+
+  const rewardConfig = clampRewardConfig({ ...REWARD_DEFAULTS, ...rewardOverrides });
+  const initialBoard = mode === 'auto' ? 10 : manualBoardSize;
+
+  const env = new VecSnakeEnv(envCount, { cols: initialBoard, rows: initialBoard, rewardConfig });
+  let boardSize = initialBoard;
+
+  const agent = new DQNAgent({
+    stateDim: env.getStateDim(),
+    actionDim: env.getActionDim(),
+    envCount,
+    gamma: gamma ?? 0.98,
+    lr: learningRate ?? (mode === 'auto' ? 5e-4 : 3e-4),
+    batchSize: batchSize ?? (mode === 'auto' ? 256 : 128),
+    bufferSize: bufferSize ?? (mode === 'auto' ? 500000 : 50000),
+    priorityAlpha: priorityAlpha ?? 0.6,
+    priorityBeta: priorityBeta ?? 0.4,
+    priorityBetaIncrement: priorityBetaIncrement ?? 0.000002,
+    epsStart: epsilon?.start ?? 1,
+    epsEnd: epsilon?.end ?? 0.12,
+    epsDecay: epsilon?.decay ?? 80000,
+    targetSync: targetSync ?? 2000,
+    nStep: nStep ?? 3,
+    warmupSteps: options.warmupSteps ?? 5000,
+  });
+
+  const metricsCollector = mode === 'auto' ? null : new MetricsCollector();
+  const scheduler = mode === 'auto'
+    ? new AutoScheduler({
+        initialConfig: agent.getHyperparams(),
+        rewardConfig,
+        minSaveCooldownMinutes,
+      })
+    : null;
+
+  const contexts = env.reset().map((state) => createEpisodeContext(state));
+  let totalEpisodes = 0;
+  let totalSteps = 0;
+  let stopRequested = false;
+  let lastPeriodicCheckpointEpisode = 0;
+  let lastPeriodicCheckpointTime = Date.now();
+  let lastAdjustments = [];
+
+  const shutdown = async (signal, err) => {
+    if (stopRequested) return;
+    if (err) console.error('[TRAIN] Fatal error', err);
+    console.log(`[TRAIN] Received ${signal}, stopping...`);
+    stopRequested = true;
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+  process.on('uncaughtException', (err) => shutdown('uncaughtException', err));
+
+  const metrics = () => (mode === 'auto' ? scheduler.getMetrics() : metricsCollector.getSummary());
+
+  const flushFinalCheckpoint = async () => {
+    const now = Date.now();
+    const episodesSinceSave = totalEpisodes - lastPeriodicCheckpointEpisode;
+    const minutesSinceSave = (now - lastPeriodicCheckpointTime) / 60000;
+    if (
+      episodesSinceSave < checkpointIntervalEpisodes ||
+      minutesSinceSave < Math.max(checkpointIntervalMinutes, minSaveCooldownMinutes)
+    ) {
+      return;
+    }
+    const summary = metrics();
+    const agentState = await agent.exportState();
+    const meta = {
+      mode,
+      episode: totalEpisodes,
+      steps: totalSteps,
+      totalSteps,
+      envCount,
+      boardSize,
+      metrics: summary,
+      hyperparams: agent.getHyperparams(),
+    };
+    await checkpointManager.save({
+      agentState,
+      rewardConfig,
+      meta,
+      reason: 'final',
+      isBest: false,
+    });
+  };
+
+  while (!stopRequested) {
+    const actions = contexts.map((ctx) => agent.act(ctx.state));
+    const stepResult = env.step(actions);
+    stepResult.nextStates.forEach((nextState, idx) => {
+      const ctx = contexts[idx];
+      const reward = stepResult.rewards[idx];
+      const done = stepResult.dones[idx];
+      const info = stepResult.infos[idx] ?? {};
+      agent.recordTransition(idx, ctx.state, actions[idx], reward, nextState, done);
+      ctx.state = nextState;
+      ctx.totalReward += reward;
+      ctx.steps += 1;
+      ctx.loopHits += info.loopPenaltyApplied ? 1 : 0;
+      ctx.revisitPenalty += info.revisitPenalty ?? 0;
+      if (info.timeToFruit) ctx.timeToFruit.push(info.timeToFruit);
+      if (info.ateFruit) ctx.fruits += 1;
+      if (info.crash) ctx.crash = info.crash;
+      totalSteps += 1;
+    });
+
+    agent.setGlobalStep(totalSteps);
+    const learnResult = await agent.learn();
+    if (learnResult) {
+      if (mode === 'auto') scheduler.metrics.recordLoss(learnResult.loss);
+      else metricsCollector.recordLoss(learnResult.loss);
+    }
+
+    for (let i = 0; i < contexts.length; i += 1) {
+      if (!stepResult.dones[i]) continue;
+      const ctx = contexts[i];
+      const record = {
+        reward: ctx.totalReward,
+        fruits: ctx.fruits,
+        length: ctx.steps,
+        crash: ctx.crash,
+        loopHits: ctx.loopHits,
+        revisitPenalty: ctx.revisitPenalty,
+        timeToFruitSamples: ctx.timeToFruit,
+      };
+      if (mode === 'auto') scheduler.recordEpisode(record);
+      else metricsCollector.recordEpisode(metricsCollector.toEpisodeRecord(record));
+      const newState = env.resetEnv(i);
+      contexts[i] = createEpisodeContext(newState);
+      totalEpisodes += 1;
+
+      const summary = metrics();
+      if (mode === 'auto') {
+        const tdStats = agent.getTdErrorStats();
+        scheduler.observe(summary, tdStats, totalEpisodes);
+        lastAdjustments = scheduler.tuneHyperparams(agent, rewardConfig, summary, tdStats, totalEpisodes) || [];
+        if (lastAdjustments.some((adj) => adj.type === 'reward')) {
+          env.setRewardConfig(rewardConfig);
+        }
+        const newBoard = scheduler.maybeAdvanceBoard(totalEpisodes);
+        if (newBoard) {
+          boardSize = newBoard;
+          env.setBoardSize(boardSize, boardSize);
+          const resetStates = env.reset();
+          resetStates.forEach((state, idx) => {
+            contexts[idx] = createEpisodeContext(state);
+          });
+          agent.pruneReplay(0.5);
+          const now = Date.now();
+          if (scheduler.shouldCheckpoint(now)) {
+            const agentState = await agent.exportState();
+            const meta = {
+              mode,
+              episode: totalEpisodes,
+              steps: totalSteps,
+              totalSteps,
+              envCount,
+              boardSize,
+              metrics: summary,
+              hyperparams: agent.getHyperparams(),
+              adjustments: lastAdjustments,
+            };
+            await checkpointManager.save({
+              agentState,
+              rewardConfig,
+              meta,
+              reason: 'board_change',
+              isBest: false,
+            });
+            lastPeriodicCheckpointEpisode = totalEpisodes;
+            lastPeriodicCheckpointTime = now;
+          }
+        }
+        if (scheduler.maybeEval(totalEpisodes)) {
+          scheduler.registerEval(totalEpisodes);
+          const evalResult = await runEvaluation(agent, boardSize, rewardConfig, options.evalEpisodes ?? 5);
+          await logger.logEval({ episode: totalEpisodes, fruitsAvg: evalResult.fruitsAvg, fruitsPerEpisode: evalResult.perEpisode });
+          const improved = scheduler.updateBestEval(totalEpisodes, evalResult.fruitsAvg, { boardSize });
+          const nowEval = Date.now();
+          if (improved && scheduler.shouldCheckpoint(nowEval)) {
+            const agentState = await agent.exportState();
+            const meta = {
+              mode,
+              episode: totalEpisodes,
+              steps: totalSteps,
+              totalSteps,
+              envCount,
+              boardSize,
+              metrics: summary,
+              hyperparams: agent.getHyperparams(),
+              eval: evalResult,
+            };
+            await checkpointManager.save({
+              agentState,
+              rewardConfig,
+              meta,
+              reason: 'best_eval',
+              isBest: true,
+            });
+            lastPeriodicCheckpointEpisode = totalEpisodes;
+            lastPeriodicCheckpointTime = nowEval;
+          }
+          const metricsAfterEval = metrics();
+          if (scheduler.needsRollback(metricsAfterEval, totalEpisodes)) {
+            const bestDir = path.join(saveDir, 'best');
+            try {
+              const meta = await loadCheckpoint(agent, rewardConfig, env, bestDir);
+              if (meta.boardSize) {
+                boardSize = meta.boardSize;
+                env.setBoardSize(boardSize, boardSize);
+              }
+              const resetStates = env.reset();
+              resetStates.forEach((state, idx) => {
+                contexts[idx] = createEpisodeContext(state);
+              });
+              agent.flushTransitions?.();
+              console.warn('[TRAIN] Rollback to best checkpoint due to regression');
+            } catch (err) {
+              console.error('[TRAIN] Failed to rollback', err);
+            }
+          }
+        }
+      }
+
+      logger.maybeLogConsole({ episode: totalEpisodes, metrics: summary, agent });
+      await logger.maybeLogJson({ episode: totalEpisodes, metrics: summary, agent, adjustments: lastAdjustments });
+
+      const now = Date.now();
+      const episodesSinceSave = totalEpisodes - lastPeriodicCheckpointEpisode;
+      const minutesSinceSave = (now - lastPeriodicCheckpointTime) / 60000;
+      if (
+        totalEpisodes > 0 &&
+        episodesSinceSave >= checkpointIntervalEpisodes &&
+        minutesSinceSave >= checkpointIntervalMinutes
+      ) {
+        const agentState = await agent.exportState();
+        const meta = {
+          mode,
+          episode: totalEpisodes,
+          steps: totalSteps,
+          totalSteps,
+          envCount,
+          boardSize,
+          metrics: summary,
+          hyperparams: agent.getHyperparams(),
+          adjustments: lastAdjustments,
+        };
+        await checkpointManager.save({ agentState, rewardConfig, meta, reason: 'periodic' });
+        lastPeriodicCheckpointEpisode = totalEpisodes;
+        lastPeriodicCheckpointTime = now;
+      }
+    }
+  }
+
+  try {
+    agent.flushTransitions?.();
+    logger.lastLogEpisode = totalEpisodes - logIntervalEpisodes;
+    await logger.maybeLogJson({
+      episode: totalEpisodes,
+      metrics: metrics(),
+      agent,
+      adjustments: lastAdjustments,
+      extra: { final: true },
+    });
+  } catch (err) {
+    console.error('[TRAIN] Failed to log final metrics', err);
+  }
+
+  await flushFinalCheckpoint();
+
+  process.removeAllListeners('SIGINT');
+  process.removeAllListeners('SIGTERM');
+  process.removeAllListeners('uncaughtException');
+}

--- a/src/utils/fs_utils.js
+++ b/src/utils/fs_utils.js
@@ -1,0 +1,116 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export async function ensureDir(dirPath) {
+  await fs.mkdir(dirPath, { recursive: true });
+}
+
+export async function writeJsonAtomic(targetPath, data) {
+  const dir = path.dirname(targetPath);
+  await ensureDir(dir);
+  const tempPath = path.join(dir, `.tmp_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+  const json = JSON.stringify(data, null, 2);
+  await fs.writeFile(tempPath, json);
+  await fs.rename(tempPath, targetPath);
+}
+
+export async function writeJsonWithFsync(filePath, data) {
+  const dir = path.dirname(filePath);
+  await ensureDir(dir);
+  const handle = await fs.open(filePath, 'w');
+  try {
+    await handle.writeFile(JSON.stringify(data, null, 2));
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function writeFileAtomic(targetPath, contents) {
+  const dir = path.dirname(targetPath);
+  await ensureDir(dir);
+  const tempPath = path.join(dir, `.tmp_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+  await fs.writeFile(tempPath, contents);
+  await fs.rename(tempPath, targetPath);
+}
+
+export async function directorySizeMB(dirPath) {
+  async function walk(current) {
+    let size = 0;
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        size += await walk(entryPath);
+      } else {
+        const stat = await fs.stat(entryPath);
+        size += stat.size;
+      }
+    }
+    return size;
+  }
+  try {
+    const sizeBytes = await walk(dirPath);
+    return sizeBytes / (1024 * 1024);
+  } catch (err) {
+    if (err.code === 'ENOENT') return 0;
+    throw err;
+  }
+}
+
+export async function removeDir(target) {
+  try {
+    await fs.rm(target, { recursive: true, force: true });
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+export async function listSubdirs(dirPath) {
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => ({
+      name: entry.name,
+      fullPath: path.join(dirPath, entry.name),
+    }));
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+export async function safeUnlink(filePath) {
+  try {
+    await fs.unlink(filePath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+export async function withTempDir(baseDir, fn) {
+  const tempDir = path.join(baseDir, `.tmp_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+  await ensureDir(tempDir);
+  try {
+    const result = await fn(tempDir);
+    return result;
+  } finally {
+    await removeDir(tempDir);
+  }
+}
+
+export function nowISO() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/ring_buffer.js
+++ b/src/utils/ring_buffer.js
@@ -1,0 +1,106 @@
+export class RingBuffer {
+  constructor(capacity) {
+    if (!Number.isFinite(capacity) || capacity <= 0) {
+      throw new Error('RingBuffer capacity must be > 0');
+    }
+    this.capacity = capacity | 0;
+    this.values = new Array(this.capacity);
+    this.index = 0;
+    this.length = 0;
+  }
+
+  push(value) {
+    this.values[this.index] = value;
+    this.index = (this.index + 1) % this.capacity;
+    if (this.length < this.capacity) {
+      this.length++;
+    }
+  }
+
+  clear() {
+    this.index = 0;
+    this.length = 0;
+    this.values.fill(undefined);
+  }
+
+  toArray() {
+    if (!this.length) return [];
+    const result = new Array(this.length);
+    const start = (this.index - this.length + this.capacity) % this.capacity;
+    for (let i = 0; i < this.length; i++) {
+      result[i] = this.values[(start + i) % this.capacity];
+    }
+    return result;
+  }
+
+  last() {
+    if (!this.length) return undefined;
+    const idx = (this.index - 1 + this.capacity) % this.capacity;
+    return this.values[idx];
+  }
+}
+
+export function mean(arr) {
+  if (!arr?.length) return 0;
+  return arr.reduce((a, b) => a + b, 0) / arr.length;
+}
+
+export function std(arr) {
+  if (!arr?.length) return 0;
+  const m = mean(arr);
+  const variance = arr.reduce((acc, value) => acc + (value - m) ** 2, 0) / arr.length;
+  return Math.sqrt(variance);
+}
+
+export function percentile(arr, p) {
+  if (!arr?.length) return 0;
+  const values = [...arr].sort((a, b) => a - b);
+  const rank = (p / 100) * (values.length - 1);
+  const lower = Math.floor(rank);
+  const upper = Math.ceil(rank);
+  if (lower === upper) return values[lower];
+  const weight = rank - lower;
+  return values[lower] * (1 - weight) + values[upper] * weight;
+}
+
+export function linearRegressionSlope(samples) {
+  if (!samples?.length || samples.length < 2) return 0;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  const n = samples.length;
+  for (let i = 0; i < n; i++) {
+    const x = i;
+    const y = samples[i];
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const denominator = n * sumXX - sumX ** 2;
+  if (denominator === 0) return 0;
+  return (n * sumXY - sumX * sumY) / denominator;
+}
+
+export function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function movingAverage(values, window) {
+  if (!values?.length) return [];
+  const result = [];
+  let acc = 0;
+  const queue = [];
+  for (const value of values) {
+    queue.push(value);
+    acc += value;
+    if (queue.length > window) {
+      acc -= queue.shift();
+    }
+    if (queue.length === window) {
+      result.push(acc / window);
+    }
+  }
+  return result;
+}

--- a/train.js
+++ b/train.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import path from 'path';
+import { runTraining } from './src/training/run_training.js';
+
+function parseArgs(argv) {
+  const result = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      result[key] = true;
+    } else {
+      result[key] = next;
+      i += 1;
+    }
+  }
+  return result;
+}
+
+function toNumber(value, fallback) {
+  if (value === undefined || value === null) return fallback;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const mode = args.mode === 'manual' ? 'manual' : 'auto';
+  const envCount = toNumber(args.envCount, mode === 'auto' ? 12 : 1);
+  const saveDir = path.resolve(args.saveDir ?? path.join('models', mode));
+
+  const config = {
+    mode,
+    envCount,
+    saveDir,
+    checkpointIntervalEpisodes: toNumber(args['checkpoint-interval-episodes'], 5000),
+    checkpointIntervalMinutes: toNumber(args['checkpoint-interval-minutes'], 60),
+    retainCheckpoints: toNumber(args['retain-checkpoints'], 5),
+    saveCapMB: toNumber(args['save-cap-mb'], 1024),
+    logCapMB: toNumber(args['log-cap-mb'], 200),
+    retainLogs: toNumber(args['retain-logs'], 3),
+    logIntervalEpisodes: toNumber(args['log-interval-episodes'], 500),
+    consoleIntervalEpisodes: toNumber(args['console-interval-episodes'], 200),
+    minSaveCooldownMinutes: toNumber(args['min-save-cooldown-minutes'], 10),
+    batchSize: toNumber(args.batchSize, undefined),
+    bufferSize: toNumber(args.bufferSize, undefined),
+    epsilon: {
+      start: toNumber(args['eps-start'], undefined),
+      end: toNumber(args['eps-end'], undefined),
+      decay: toNumber(args['eps-decay'], undefined),
+    },
+    gamma: toNumber(args.gamma, undefined),
+    learningRate: toNumber(args.lr, undefined),
+    nStep: toNumber(args['n-step'], undefined),
+    targetSync: toNumber(args['target-sync'], undefined),
+    priorityAlpha: toNumber(args['priority-alpha'], undefined),
+    priorityBeta: toNumber(args['priority-beta'], undefined),
+    priorityBetaIncrement: toNumber(args['priority-beta-increment'], undefined),
+    manualBoardSize: toNumber(args['board-size'], 20),
+  };
+
+  try {
+    await runTraining(config);
+  } catch (err) {
+    console.error('[TRAIN] Fatal error', err);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
* add a Node-based training pipeline that wires the new VecSnakeEnv, replay buffer, disk-aware checkpointing and scheduler-driven training loop into both auto and manual modes
* implement the AutoScheduler with curriculum upgrades, adaptive epsilon/lr/PER/reward tuning, evaluation handling, and rollback logic
* expose a CLI entry point and refresh the README with usage details, disk/log policies, and workflow examples
* update the browser watch button to import the latest checkpoint through the File System Access API so it can display saved models

## Testing
* ⚠️ `timeout 1s node train.js --mode manual --envCount 1 --saveDir /tmp/snake-test` *(fails: missing local install of @tensorflow/tfjs-node)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a0033050832499becfe8b2ac6236