### PR TITLE
Arrange training layout in two columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,8 @@ main.layout{
   padding:0 24px 40px;
   display:grid;
   gap:32px;
+  grid-template-columns:minmax(0,560px) minmax(0,1fr);
+  align-items:start;
 }
 .card{
   background:linear-gradient(155deg,rgba(34,41,82,0.88) 0%,rgba(18,21,46,0.92) 100%);
@@ -103,6 +105,11 @@ main.layout{
   flex-direction:column;
   gap:18px;
   backdrop-filter:blur(18px);
+}
+.game-card{grid-column:1;}
+.control-card{
+  grid-column:2;
+  align-self:start;
 }
 .card-head{
   display:flex;


### PR DESCRIPTION
## Summary
- update the training layout grid to provide a dedicated right-hand column for the static controls
- keep the simulation card anchored in the left column while aligning the control panel to the right
- preserve the single-column responsive fallback for narrow viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3e74dfb9c8324b269debf0d9b51ce