### PR TITLE
Restore three-column training layout and live grid size updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ header{
   box-shadow:0 20px 40px rgba(6,8,20,0.6);
 }
 header .header-inner{
-  max-width:1180px;
+  max-width:1480px;
   margin:0 auto;
   padding:0 32px;
   display:flex;
@@ -87,11 +87,14 @@ header .header-inner{
   border-color:rgba(139,92,246,0.45);
 }
 main.layout{
-  max-width:1180px;
+  max-width:1480px;
   margin:32px auto 48px;
   padding:0 24px 40px;
   display:grid;
   gap:32px;
+  grid-template-columns:minmax(520px,1fr) minmax(260px,320px) minmax(260px,320px);
+  align-items:start;
+  grid-auto-flow:row;
 }
 .card{
   background:linear-gradient(155deg,rgba(34,41,82,0.88) 0%,rgba(18,21,46,0.92) 100%);
@@ -103,6 +106,15 @@ main.layout{
   flex-direction:column;
   gap:18px;
   backdrop-filter:blur(18px);
+}
+.game-card{grid-column:1;}
+.control-card{
+  grid-column:2;
+  align-self:start;
+}
+.tuning-card{
+  grid-column:3;
+  align-self:start;
 }
 .card-head{
   display:flex;
@@ -639,12 +651,25 @@ footer{
   padding:18px;
   font-size:12px;
 }
+@media(max-width:1200px){
+  main.layout{
+    grid-template-columns:minmax(0,560px) minmax(0,1fr);
+  }
+  .control-card{
+    grid-column:2;
+  }
+  .tuning-card{
+    grid-column:2;
+    grid-row:2;
+  }
+}
 @media(max-width:1050px){
   main.layout{
     grid-template-columns:1fr;
   }
   .game-card,
-  .control-card{
+  .control-card,
+  .tuning-card{
     grid-column:1;
   }
   canvas#board{
@@ -808,6 +833,13 @@ footer{
         </table>
       </div>
     </div>
+  </section>
+
+  <section class="card tuning-card">
+    <div class="card-head">
+      <h2>Reward &amp; tuning</h2>
+      <span class="hint">Adjust incentives and hyperparameters.</span>
+    </div>
 
     <details id="rewardPanel" open>
       <summary>Reward model</summary>
@@ -893,16 +925,16 @@ footer{
       <summary>Advanced settings</summary>
       <div class="stack" data-config="shared">
         <h3>Shared</h3>
-      <div class="row">
-        <label>Parallel environments
-          <input type="range" id="envCount" min="1" max="24" step="1" value="1">
-          <span class="mono" id="envCountReadout">1</span>
-        </label>
-        <label>γ (discount)
-          <input type="range" id="gamma" min="0.90" max="0.999" step="0.001" value="0.98">
-          <span class="mono" id="gammaReadout">0.98</span>
-        </label>
-        <label>LR
+        <div class="row">
+          <label>Parallel environments
+            <input type="range" id="envCount" min="1" max="24" step="1" value="1">
+            <span class="mono" id="envCountReadout">1</span>
+          </label>
+          <label>γ (discount)
+            <input type="range" id="gamma" min="0.90" max="0.999" step="0.001" value="0.98">
+            <span class="mono" id="gammaReadout">0.98</span>
+          </label>
+          <label>LR
             <input type="range" id="lr" min="0.0001" max="0.005" step="0.0001" value="0.0005">
             <span class="mono" id="lrReadout">0.0005</span>
           </label>
@@ -3175,7 +3207,10 @@ function bindUI(){
   });
   ui.gridSize.addEventListener('input',()=>{
     updateGridLabel();
-    if(!training) reconfigureEnvironment({ size:+ui.gridSize.value, force:true });
+    const desiredSize=Math.max(8,(+ui.gridSize.value)|0);
+    if(desiredSize!==COLS){
+      resetEnvironment(desiredSize,true);
+    }
   });
   ui.btnReset.addEventListener('click',()=>resetEnvironment(+ui.gridSize.value,true));
   ui.btnTrain.addEventListener('click',startTraining);


### PR DESCRIPTION
## Summary
- widen the header and training grid containers so the three-column layout remains visible on wider desktops
- adjust the responsive breakpoint to keep the tuning panel in the right-hand column until narrower screens
- reset the environment when the grid-size slider moves so manual mode boards resize immediately without toggling env count

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3e74dfb9c8324b269debf0d9b51ce