### PR TITLE
Inject OpenAI key during Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy Snake-ML to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Inject OpenAI API key bootstrap script
+        run: |
+          mkdir -p public
+          echo "window.__OPENAI_KEY = '${{ secrets.OPENAI_API_KEY }}';" > public/__key.js
+
+      - name: Prepare static site bundle
+        run: |
+          rm -rf dist
+          mkdir -p dist
+          cp index.html dist/
+          if [ -f ai-tuner.js ]; then cp ai-tuner.js dist/; fi
+          if [ -d src ]; then cp -R src dist/src; fi
+          if [ -d public ]; then cp -R public/. dist/; fi
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v3

--- a/README.md
+++ b/README.md
@@ -10,6 +10,31 @@ Refactored reinforcement learning playground for the Snake environment with supp
 - **Disk guardrails** – checkpoints and logs honour interval, cooldown, retention and disk size caps with atomic writes and automatic pruning.
 - **Evaluations & rollback** – lightweight greedy evaluations every 2000 episodes, best-model retention, and rollback on catastrophic regression.
 
+## AI Auto-Tune API key
+
+The browser-side AI Auto-Tune module calls OpenAI's GPT-4o-mini endpoint. It requires `OPENAI_API_KEY` to be present at runtime.
+
+### Local development
+
+1. Create a `.env` file in the project root containing your key:
+   ```env
+   OPENAI_API_KEY=sk-your-key
+   ```
+2. Export the variables before starting a dev server or static file host, for example:
+   ```bash
+   set -a
+   source .env
+   set +a
+   npx http-server .
+   ```
+   Any tooling (`vite`, `webpack-dev-server`, etc.) works as long as it is launched from the same shell session so that `process.env.OPENAI_API_KEY` is populated.
+
+### GitHub Pages / Actions
+
+1. In your repository settings, add a secret named `OPENAI_API_KEY` containing the key.
+2. The `deploy.yml` workflow writes `public/__key.js` before the build runs, injecting the key via `window.__OPENAI_KEY = '${{ secrets.OPENAI_API_KEY }}';` so the browser can read it.
+3. Because the bootstrap script ships with the published HTML, the secret is exposed to clients — treat it as a public token scoped only for this project.
+
 ## CLI usage
 
 Training is handled through `train.js`. Install dependencies with `npm install` and start training, for example:

--- a/ai-tuner.js
+++ b/ai-tuner.js
@@ -1,0 +1,1 @@
+export { createAITuner } from './src/ai-tuner.js';

--- a/index.html
+++ b/index.html
@@ -184,6 +184,53 @@ canvas#board{
   border:1px solid rgba(128,138,206,0.2);
   box-shadow:0 16px 34px rgba(6,10,30,0.38);
 }
+.ai-auto-tune{
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+  background:rgba(19,24,54,0.6);
+  border-radius:16px;
+  padding:14px 16px;
+  border:1px solid rgba(128,138,206,0.2);
+  box-shadow:0 16px 34px rgba(6,10,30,0.38);
+}
+.ai-auto-tune__header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:16px;
+}
+.ai-auto-tune__header h3{
+  margin:0;
+  font-size:14px;
+  letter-spacing:0.06em;
+  text-transform:uppercase;
+  color:#e7ebff;
+}
+.ai-auto-tune__header .hint{
+  margin:4px 0 0;
+}
+.ai-auto-tune__controls{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:18px;
+  flex-wrap:wrap;
+}
+.toggle{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  color:#e7ebff;
+  font-weight:600;
+  cursor:pointer;
+}
+.toggle input[type="checkbox"]{
+  width:18px;
+  height:18px;
+  accent-color:var(--accent-a);
+  cursor:pointer;
+}
 button{
   appearance:none;
   border:none;
@@ -540,6 +587,8 @@ select{
 .auto-log__entry--reward{border-left-color:#ff8da4;}
 .auto-log__entry--summary{border-left-color:#8d99ff;}
 .auto-log__entry--info{border-left-color:var(--accent-a);}
+.auto-log__entry--ai{border-left-color:#22d3ee;}
+.auto-log__entry--error{border-left-color:var(--danger);}
 .auto-log__title{
   font-weight:600;
   color:#e5e9ff;
@@ -782,6 +831,27 @@ footer{
       </select>
     </div>
     <p class="hint" id="algoDescription">Prioritized replay, n-step returns, and dueling heads make DQN stable and sample efficient.</p>
+
+    <div class="ai-auto-tune" id="aiAutoTunePanel">
+      <div class="ai-auto-tune__header">
+        <div>
+          <h3>AI Auto-Tune</h3>
+          <p class="hint">LLM-analys justerar belöningar och hyperparametrar för att maximera överlevnad och frukt.</p>
+        </div>
+        <label class="toggle" for="aiAutoTuneToggle">
+          <input type="checkbox" id="aiAutoTuneToggle" aria-label="Aktivera AI Auto-Tune">
+          <span>Aktivera</span>
+        </label>
+      </div>
+      <div class="ai-auto-tune__controls">
+        <span class="hint">Analysera var</span>
+        <div class="field compact">
+          <label for="aiIntervalSlider">Avslutade episoder</label>
+          <input type="range" id="aiIntervalSlider" min="100" max="5000" step="100" value="1000">
+          <span class="mono" id="aiIntervalReadout">1000 ep</span>
+        </div>
+      </div>
+    </div>
 
     <div id="autoLogPanel" class="auto-log hidden">
       <div class="auto-log__header">
@@ -1204,8 +1274,10 @@ footer{
 
 <footer class="hint">© Marcus — Snake learns with multiple RL strategies and cinematic movement.</footer>
 
-<script>
-'use strict';
+<script src="__key.js"></script>
+<script type="module" src="ai-tuner.js"></script>
+<script type="module">
+import {createAITuner} from './ai-tuner.js';
 
 const REWARD_DEFAULTS={
   stepPenalty:0.01,
@@ -2878,6 +2950,9 @@ const ui={
   modeButtons:Array.from(document.querySelectorAll('#modeGroup .pill')),
   algoSelect:document.getElementById('algoSelect'),
   algoDescription:document.getElementById('algoDescription'),
+  aiAutoTuneToggle:document.getElementById('aiAutoTuneToggle'),
+  aiIntervalSlider:document.getElementById('aiIntervalSlider'),
+  aiIntervalReadout:document.getElementById('aiIntervalReadout'),
   gamma:document.getElementById('gamma'),
   gammaReadout:document.getElementById('gammaReadout'),
   lr:document.getElementById('lr'),
@@ -2992,6 +3067,10 @@ const autoLogEntries=[];
 const MAX_AUTO_LOG_ENTRIES=24;
 let lastAutoMetrics=null;
 let lastAutoSummaryEpisode=0;
+const aiEpisodeHistory=[];
+let aiAnalysisInterval=1000;
+let aiAutoTuneEnabled=false;
+let aiTuner=null;
 function avg(arr,n){
   if(!arr.length) return 0;
   const slice=arr.slice(-n);
@@ -3089,7 +3168,8 @@ function resetAutoLog(){
 }
 function updateAutoLogVisibility(){
   if(!ui.autoLogPanel) return;
-  ui.autoLogPanel.classList.toggle('hidden',trainingMode!=='auto');
+  const shouldShow=trainingMode==='auto'||aiAutoTuneEnabled;
+  ui.autoLogPanel.classList.toggle('hidden',!shouldShow);
 }
 function logAutoEvent({title='',detail='',metrics=null,tone='info',episode=null}={}){
   if(!ui.autoLogStream) return;
@@ -3184,6 +3264,223 @@ function logAutoSummary(metrics,episodeNumber){
   logAutoEvent({title:'Auto check-in',detail:'No new adjustments',metrics,tone:'summary',episode:episodeNumber});
 }
 
+function round(value,decimals=3){
+  const num=Number(value);
+  if(!Number.isFinite(num)) return 0;
+  const factor=10**decimals;
+  return Math.round(num*factor)/factor;
+}
+
+function updateAiIntervalReadout(){
+  if(!ui.aiIntervalSlider||!ui.aiIntervalReadout) return;
+  const raw=+ui.aiIntervalSlider.value||aiAnalysisInterval||1000;
+  aiAnalysisInterval=Math.max(100,Math.min(5000,Math.round(raw/100)*100));
+  ui.aiIntervalReadout.textContent=`${aiAnalysisInterval} ep`;
+  if(aiTuner) aiTuner.setInterval(aiAnalysisInterval);
+}
+
+function getHyperparameterSnapshot(){
+  const snapshot={
+    gamma:+ui.gamma?.value||0,
+    lr:+ui.lr?.value||0,
+    envCount,
+    epsilon:agent?.epsilon??null,
+    agentKind:agent?.kind||null,
+  };
+  if(agent?.kind==='dqn'){
+    Object.assign(snapshot,{
+      epsStart:+ui.epsStart?.value||0,
+      epsEnd:+ui.epsEnd?.value||0,
+      epsDecay:+ui.epsDecay?.value||0,
+      batch:+ui.batchSize?.value||0,
+      bufferSize:+ui.bufferSize?.value||0,
+      targetSync:+ui.targetSync?.value||0,
+      nStep:+ui.nStep?.value||0,
+      priorityAlpha:+ui.priorityAlpha?.value||0,
+      priorityBeta:+ui.priorityBeta?.value||0,
+    });
+  }else if(agent?.kind==='policy'){
+    Object.assign(snapshot,{
+      entropy:+ui.pgEntropy?.value||0,
+    });
+  }else if(agent?.kind==='a2c'){
+    Object.assign(snapshot,{
+      entropy:+ui.acEntropy?.value||0,
+      valueCoef:+ui.acValueCoef?.value||0,
+    });
+  }else if(agent?.kind==='ppo'){
+    Object.assign(snapshot,{
+      entropy:+ui.ppoEntropy?.value||0,
+      valueCoef:+ui.ppoValueCoef?.value||0,
+      clip:+ui.ppoClip?.value||0,
+      lambda:+ui.ppoLambda?.value||0,
+      batch:+ui.ppoBatch?.value||0,
+      epochs:+ui.ppoEpochs?.value||0,
+    });
+  }
+  return snapshot;
+}
+
+function buildAITelemetrySnapshot(){
+  const lookback=Math.min(aiAnalysisInterval,aiEpisodeHistory.length);
+  if(!lookback) return null;
+  const recent=aiEpisodeHistory.slice(-lookback);
+  const rewardValues=[];
+  const fruitValues=[];
+  const crashCounts={};
+  const breakdownTotals={};
+  let breakdownCount=0;
+  let rewardSum=0,fruitSum=0,stepsSum=0,loopsSum=0,timeToFruitSum=0,timeToFruitCount=0;
+  recent.forEach(item=>{
+    rewardValues.push(item.reward);
+    fruitValues.push(item.fruits);
+    rewardSum+=item.reward;
+    fruitSum+=item.fruits;
+    stepsSum+=item.steps;
+    loopsSum+=item.loopHits;
+    const crashKey=item.crash||'none';
+    crashCounts[crashKey]=(crashCounts[crashKey]||0)+1;
+    if(item.timeToFruitAvg!==null&&item.timeToFruitAvg!==undefined){
+      timeToFruitSum+=item.timeToFruitAvg;
+      timeToFruitCount++;
+    }
+    if(item.breakdown){
+      breakdownCount++;
+      Object.entries(item.breakdown).forEach(([key,val])=>{
+        breakdownTotals[key]=(breakdownTotals[key]||0)+(+val||0);
+      });
+    }
+  });
+  const rewardAvg=rewardSum/lookback;
+  const fruitAvg=fruitSum/lookback;
+  const stepsAvg=stepsSum/lookback;
+  const loopsAvg=loopsSum/lookback;
+  const rewardVariance=rewardValues.length?rewardValues.reduce((acc,val)=>acc+(val-rewardAvg)**2,0)/rewardValues.length:0;
+  const fruitVariance=fruitValues.length?fruitValues.reduce((acc,val)=>acc+(val-fruitAvg)**2,0)/fruitValues.length:0;
+  const rewardStd=Math.sqrt(rewardVariance);
+  const fruitStd=Math.sqrt(fruitVariance);
+  const fruitRate=stepsAvg?fruitAvg/stepsAvg:0;
+  const fillRate=(COLS*ROWS)?fruitAvg/(COLS*ROWS):0;
+  const half=Math.floor(lookback/2);
+  let rewardTrend=0,fruitTrend=0;
+  if(half>0){
+    const first=recent.slice(0,half);
+    const last=recent.slice(-half);
+    const firstReward=first.reduce((acc,item)=>acc+item.reward,0)/half;
+    const lastReward=last.reduce((acc,item)=>acc+item.reward,0)/half;
+    const firstFruit=first.reduce((acc,item)=>acc+item.fruits,0)/half;
+    const lastFruit=last.reduce((acc,item)=>acc+item.fruits,0)/half;
+    rewardTrend=lastReward-firstReward;
+    fruitTrend=lastFruit-firstFruit;
+  }
+  const stats={
+    rewardAvg:round(rewardAvg,3),
+    rewardStd:round(rewardStd,3),
+    fruitAvg:round(fruitAvg,3),
+    fruitStd:round(fruitStd,3),
+    stepsAvg:Math.round(stepsAvg),
+    loopsAvg:round(loopsAvg,3),
+    fruitRate:round(fruitRate,4),
+    fillRate:round(fillRate,4),
+    rewardTrend:round(rewardTrend,3),
+    fruitTrend:round(fruitTrend,3),
+  };
+  if(timeToFruitCount>0){
+    stats.timeToFruit=round(timeToFruitSum/timeToFruitCount,3);
+  }
+  const breakdownAvg=breakdownCount?Object.fromEntries(Object.entries(breakdownTotals).map(([key,val])=>[key,round(val/breakdownCount,4)])):undefined;
+  return {
+    meta:{
+      episode,
+      interval:lookback,
+      board:{cols:COLS,rows:ROWS},
+      envs:envCount,
+      algo:currentAlgoKey,
+      agent:agent?.kind||null,
+      best:bestLen,
+    },
+    stats,
+    crash:crashCounts,
+    rewardBreakdown:breakdownAvg,
+    rewardConfig:{...rewardConfig},
+    hyper:getHyperparameterSnapshot(),
+  };
+}
+
+function applyAITunerRewardConfig(newConfig={}){
+  const result={changes:[],config:null};
+  if(!newConfig||typeof newConfig!=='object') return result;
+  const merged={...rewardConfig};
+  Object.entries(newConfig).forEach(([key,value])=>{
+    if(!(key in merged)) return;
+    const num=Number(value);
+    if(!Number.isFinite(num)) return;
+    const current=merged[key];
+    if(Math.abs(current-num)<1e-6) return;
+    merged[key]=num;
+    result.changes.push({key,oldValue:current,newValue:num});
+  });
+  if(result.changes.length){
+    applyRewardConfigToUI(merged);
+    result.config={...merged};
+  }
+  return result;
+}
+
+function applyAITunerHyperparameters(updates={}){
+  const result={changes:[],hyper:null};
+  if(!updates||typeof updates!=='object') return result;
+  const setValue=(id,value,keyLabel)=>{
+    const input=ui[id];
+    if(!input) return;
+    let num=Number(value);
+    if(!Number.isFinite(num)) return;
+    if(input.min!==''&&input.min!==undefined) num=Math.max(num,+input.min);
+    if(input.max!==''&&input.max!==undefined) num=Math.min(num,+input.max);
+    const current=+input.value;
+    if(Math.abs(current-num)<1e-6) return;
+    input.value=`${num}`;
+    result.changes.push({key:keyLabel,oldValue:current,newValue:num});
+  };
+  if(updates.gamma!==undefined) setValue('gamma',updates.gamma,'gamma');
+  if(updates.lr!==undefined) setValue('lr',updates.lr,'lr');
+  if(updates.epsStart!==undefined) setValue('epsStart',updates.epsStart,'epsStart');
+  if(updates.epsEnd!==undefined) setValue('epsEnd',updates.epsEnd,'epsEnd');
+  if(updates.epsDecay!==undefined) setValue('epsDecay',updates.epsDecay,'epsDecay');
+  if(updates.batch!==undefined){
+    if(agent?.kind==='ppo') setValue('ppoBatch',updates.batch,'ppoBatch');
+    else setValue('batchSize',updates.batch,'batchSize');
+  }
+  if(updates.batchSize!==undefined) setValue('batchSize',updates.batchSize,'batchSize');
+  if(updates.bufferSize!==undefined) setValue('bufferSize',updates.bufferSize,'bufferSize');
+  if(updates.targetSync!==undefined) setValue('targetSync',updates.targetSync,'targetSync');
+  if(updates.nStep!==undefined) setValue('nStep',updates.nStep,'nStep');
+  if(updates.priorityAlpha!==undefined) setValue('priorityAlpha',updates.priorityAlpha,'priorityAlpha');
+  if(updates.priorityBeta!==undefined) setValue('priorityBeta',updates.priorityBeta,'priorityBeta');
+  if(updates.entropy!==undefined){
+    if(agent?.kind==='policy') setValue('pgEntropy',updates.entropy,'pgEntropy');
+    else if(agent?.kind==='a2c') setValue('acEntropy',updates.entropy,'acEntropy');
+    else if(agent?.kind==='ppo') setValue('ppoEntropy',updates.entropy,'ppoEntropy');
+  }
+  if(updates.valueCoef!==undefined){
+    if(agent?.kind==='a2c') setValue('acValueCoef',updates.valueCoef,'acValueCoef');
+    else if(agent?.kind==='ppo') setValue('ppoValueCoef',updates.valueCoef,'ppoValueCoef');
+  }
+  if(updates.clip!==undefined&&agent?.kind==='ppo') setValue('ppoClip',updates.clip,'ppoClip');
+  if(updates.lambda!==undefined&&agent?.kind==='ppo') setValue('ppoLambda',updates.lambda,'ppoLambda');
+  if(updates.epochs!==undefined&&agent?.kind==='ppo') setValue('ppoEpochs',updates.epochs,'ppoEpochs');
+  if(result.changes.length){
+    updateReadouts();
+    applyConfigToAgent();
+    result.hyper=getHyperparameterSnapshot();
+  }
+  return result;
+}
+
+function logAITunerEvent({title='',detail='',tone='ai',metrics=null,episodeNumber=null}={}){
+  logAutoEvent({title,detail,metrics,tone,episode:episodeNumber??episode});
+}
+
 function bindUI(){
   ui.playbackButtons.forEach(btn=>{
     btn.addEventListener('click',()=>{
@@ -3218,6 +3515,16 @@ function bindUI(){
   });
   ui.autoLogClear?.addEventListener('click',()=>{
     resetAutoLog();
+  });
+  ui.aiIntervalSlider?.addEventListener('input',()=>{
+    updateAiIntervalReadout();
+  });
+  ui.aiAutoTuneToggle?.addEventListener('change',()=>{
+    aiAutoTuneEnabled=ui.aiAutoTuneToggle.checked;
+    if(aiTuner) aiTuner.setEnabled(aiAutoTuneEnabled);
+    const detail=aiAutoTuneEnabled?'Aktiverad':'Avstängd';
+    logAITunerEvent({title:'AI Auto-Tune',detail,tone:'ai',episodeNumber:episode});
+    updateAutoLogVisibility();
   });
   ui.fileLoader?.addEventListener('change',async ev=>{
     const [file]=ev.target.files||[];
@@ -3266,6 +3573,8 @@ function bindUI(){
   updateControlAvailability();
   setTrainingMode(trainingMode);
   updateAutoLogVisibility();
+  updateAiIntervalReadout();
+  if(ui.aiAutoTuneToggle) ui.aiAutoTuneToggle.checked=aiAutoTuneEnabled;
 }
 function setActiveTab(tab){
   const showGuide=tab==='guide';
@@ -3957,6 +4266,7 @@ async function finalizeContextEpisode(ctx,envIndex){
   const crashType=envRef?.lastCrash??null;
   const timeToFruitTotal=envRef?.timeToFruitAccum??0;
   const timeToFruitCount=envRef?.timeToFruitCount??0;
+  const avgTimeToFruit=timeToFruitCount>0?timeToFruitTotal/timeToFruitCount:null;
   updateStatsUI();
   rewardTelemetry.record(breakdown);
   updateRewardTelemetryUI();
@@ -3992,6 +4302,17 @@ async function finalizeContextEpisode(ctx,envIndex){
       lastAutoSummaryEpisode=autoEpisode;
     }
   }
+  aiEpisodeHistory.push({
+    reward:ctx.totalReward,
+    fruits:ctx.fruits,
+    steps:ctx.steps,
+    loopHits,
+    crash:crashType||'none',
+    timeToFruitAvg:avgTimeToFruit,
+    breakdown:breakdown?{...breakdown}:null,
+  });
+  if(aiEpisodeHistory.length>6000) aiEpisodeHistory.shift();
+  if(aiTuner) aiTuner.maybeTune({episode});
   ctx.totalReward=0;
   ctx.fruits=0;
   ctx.steps=0;
@@ -4377,6 +4698,16 @@ async function loadTrainingFromFile(file){
 }
 
 /* ---------------- Init ---------------- */
+aiTuner=createAITuner({
+  getVecEnv:()=>vecEnv,
+  fetchTelemetry:()=>buildAITelemetrySnapshot(),
+  applyRewardConfig:applyAITunerRewardConfig,
+  applyHyperparameters:applyAITunerHyperparameters,
+  log:logAITunerEvent,
+});
+aiTuner.setInterval(aiAnalysisInterval);
+aiTuner.setEnabled(aiAutoTuneEnabled);
+
 window.addEventListener('load',()=>{
   bindUI();
   setPlaybackMode('cinematic');

--- a/src/ai-tuner.js
+++ b/src/ai-tuner.js
@@ -1,0 +1,181 @@
+const API_URL='https://api.openai.com/v1/chat/completions';
+const SYSTEM_PROMPT=`Du är en expert på reinforcement learning.
+Ditt mål är att justera Snake-MLs belöningsparametrar och centrala
+hyperparametrar så att ormen klarar spelet konsekvent.
+Returnera ENDAST minifierad JSON med nya värden för alla parametrar
+du vill uppdatera, t.ex.
+{
+  "rewardConfig": {stepPenalty:0.008, fruitReward:12, ...},
+  "hyper": {gamma:0.985, lr:0.0004, epsDecay:90000, ...}
+}`;
+
+function resolveApiKey(preferred){
+  if(typeof preferred==='string' && preferred.trim()) return preferred.trim();
+  if(typeof globalThis!=='undefined' && typeof globalThis.__OPENAI_KEY==='string' && globalThis.__OPENAI_KEY.trim()){
+    return globalThis.__OPENAI_KEY.trim();
+  }
+  if(typeof process!=='undefined' && process?.env?.OPENAI_API_KEY){
+    return String(process.env.OPENAI_API_KEY).trim();
+  }
+  return null;
+}
+
+function formatNumber(value){
+  if(value===null||value===undefined||Number.isNaN(value)) return '—';
+  if(typeof value==='number'){
+    const abs=Math.abs(value);
+    if(abs>=100) return value.toFixed(0);
+    if(abs>=10) return value.toFixed(1);
+    if(abs>=1) return value.toFixed(2);
+    return value.toFixed(3);
+  }
+  return String(value);
+}
+
+function formatChanges(changes=[]){
+  if(!Array.isArray(changes) || !changes.length) return '';
+  return changes.map(change=>{
+    const key=change.key??change.id??'värde';
+    const before=formatNumber(change.oldValue);
+    const after=formatNumber(change.newValue);
+    return `${key}: ${before}→${after}`;
+  }).join(', ');
+}
+
+export function createAITuner(options={}){
+  const {
+    getVecEnv=()=>null,
+    fetchTelemetry,
+    applyRewardConfig,
+    applyHyperparameters,
+    log,
+    apiKey:null,
+  }=options;
+  if(typeof fetchTelemetry!=='function'){
+    throw new Error('createAITuner requires a fetchTelemetry() function');
+  }
+  const logger=typeof log==='function'?log:()=>{};
+  const resolveEnv=typeof getVecEnv==='function'?getVecEnv:()=>getVecEnv??null;
+  let enabled=false;
+  let interval=1000;
+  let busy=false;
+  let warnedNoKey=false;
+  let warnedNoFetch=false;
+
+  function logEvent(payload){
+    try{
+      logger(payload);
+    }catch(err){
+      console.warn('[ai-tuner] failed to log event',err);
+    }
+  }
+
+  async function runTuningCycle(telemetry,episode){
+    if(typeof fetch!=='function'){
+      if(!warnedNoFetch){
+        logEvent({title:'AI Auto-Tune',detail:'fetch saknas i miljön – kan inte kontakta OpenAI.',tone:'error',episodeNumber:episode});
+        warnedNoFetch=true;
+      }
+      return;
+    }
+    const key=resolveApiKey(apiKey);
+    if(!key){
+      if(!warnedNoKey){
+        logEvent({title:'AI Auto-Tune',detail:'OPENAI_API_KEY saknas. Hoppar över justeringar.',tone:'error',episodeNumber:episode});
+        warnedNoKey=true;
+      }
+      return;
+    }
+    const payload=JSON.stringify(telemetry);
+    const response=await fetch(API_URL,{
+      method:'POST',
+      headers:{
+        'Content-Type':'application/json',
+        Authorization:`Bearer ${key}`,
+      },
+      body:JSON.stringify({
+        model:'gpt-4o-mini',
+        temperature:0.2,
+        messages:[
+          {role:'system',content:SYSTEM_PROMPT},
+          {role:'user',content:payload},
+        ],
+        response_format:{type:'json_object'},
+      }),
+    });
+    if(!response.ok){
+      const text=await response.text();
+      throw new Error(`OpenAI ${response.status}: ${text.slice(0,200)}`);
+    }
+    const data=await response.json();
+    const content=data?.choices?.[0]?.message?.content;
+    if(!content){
+      throw new Error('Saknar innehåll i OpenAI-svar.');
+    }
+    let parsed;
+    try{
+      parsed=JSON.parse(content);
+    }catch(err){
+      throw new Error(`Kunde inte tolka JSON: ${content}`);
+    }
+    const rewardResult=typeof applyRewardConfig==='function'
+      ?applyRewardConfig(parsed.rewardConfig||parsed.reward||{})
+      :{changes:[],config:null};
+    const hyperResult=typeof applyHyperparameters==='function'
+      ?applyHyperparameters(parsed.hyper||parsed.hyperparameters||{})
+      :{changes:[],hyper:null};
+    const envInstance=resolveEnv?.();
+    if(envInstance?.setRewardConfig && rewardResult?.config){
+      try{
+        envInstance.setRewardConfig(rewardResult.config);
+      }catch(err){
+        console.warn('[ai-tuner] setRewardConfig failed',err);
+      }
+    }
+    const rewardSummary=formatChanges(rewardResult?.changes);
+    const hyperSummary=formatChanges(hyperResult?.changes);
+    if(rewardSummary){
+      logEvent({title:'AI belöningar',detail:rewardSummary,tone:'reward',episodeNumber:episode});
+    }
+    if(hyperSummary){
+      logEvent({title:'AI hyperparametrar',detail:hyperSummary,tone:'lr',episodeNumber:episode});
+    }
+    if(!rewardSummary && !hyperSummary){
+      logEvent({title:'AI Auto-Tune',detail:'Ingen justering rekommenderades.',tone:'ai',episodeNumber:episode});
+    }
+  }
+
+  function maybeTune({episode}={}){
+    if(!enabled) return;
+    if(!episode || episode%interval!==0) return;
+    if(busy) return;
+    busy=true;
+    (async()=>{
+      try{
+        const telemetry=await Promise.resolve(fetchTelemetry({interval,episode}));
+        if(!telemetry){
+          return;
+        }
+        await runTuningCycle(telemetry,episode);
+      }catch(err){
+        console.error('[ai-tuner]',err);
+        logEvent({title:'AI Auto-Tune',detail:err.message||String(err),tone:'error',episodeNumber:episode});
+      }finally{
+        busy=false;
+      }
+    })();
+  }
+
+  return {
+    setEnabled(value){ enabled=!!value; },
+    setInterval(value){
+      const num=Number(value);
+      if(Number.isFinite(num) && num>0){
+        interval=Math.max(1,Math.floor(num));
+      }
+    },
+    maybeTune,
+    isEnabled(){ return enabled; },
+    getInterval(){ return interval; },
+  };
+}


### PR DESCRIPTION
## Summary
- create a deploy workflow that injects OPENAI_API_KEY into public/__key.js before packaging the static site
- expose the key to the browser by loading __key.js ahead of the AI tuner module
- document that the GitHub Pages build publishes the injected key and should be treated as public

## Testing
- not run (configuration and static updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d443cdc800832491703d571f0edf2b