### PR TITLE
Improve proxy parsing resilience and logging

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -37,17 +37,17 @@ app.post('/api/proxy', async (req, res) => {
       return res.status(500).json({ error: 'HF_TOKEN saknas i miljön.' });
     }
 
-const payload = {
-  inputs: `${
-    typeof instruction === 'string' && instruction.trim()
-      ? instruction
-      : SYSTEM_PROMPT
-  }\n\n${JSON.stringify(telemetry)}`,
-  parameters: {
-    temperature: 0.2,
-    max_new_tokens: 300,
-  },
-};
+    const payload = {
+      inputs: `${
+        typeof instruction === 'string' && instruction.trim()
+          ? instruction
+          : SYSTEM_PROMPT
+      }\n\n${JSON.stringify(telemetry)}`,
+      parameters: {
+        temperature: 0.2,
+        max_new_tokens: 300,
+      },
+    };
 
     const response = await fetch(HF_API_URL, {
       method: 'POST',
@@ -60,32 +60,157 @@ const payload = {
 
     const text = await response.text();
     console.log('HF raw response:', text);
-    const content = text ? safeJsonParse(text) : null;
+    let content = null;
+    let parseError = null;
+    const contentType = response.headers.get('content-type') || '';
+
+    if (text) {
+      try {
+        content = safeJsonParse(text);
+      } catch (err) {
+        parseError = err;
+        const recovered = tryRecoverInlineJson(text);
+        if (recovered !== null) {
+          content = recovered;
+          parseError = null;
+        }
+      }
+    }
+
+    const rawText = typeof text === 'string' ? text : '';
 
     if (!response.ok) {
-      const message = (content && content.error) || text || `Hugging Face svarade ${response.status}`;
+      const upstreamError =
+        (content && typeof content.error === 'string' && content.error.trim())
+          ? content.error.trim()
+          : rawText.trim();
+
+      let message;
+      if (response.status === 401) {
+        message = 'Ogiltig eller saknad Hugging Face-token.';
+      } else if (response.status === 403) {
+        message = 'Behörighet saknas för den valda Hugging Face-modellen.';
+      } else if (response.status === 404) {
+        message = 'Hugging Face rapporterade 404 (Not Found). Kontrollera modellnamnet.';
+      } else if (upstreamError) {
+        message = upstreamError;
+      } else {
+        message = `Hugging Face svarade ${response.status}`;
+      }
+
       return res.status(response.status).json({
         error: typeof message === 'string' ? message.slice(0, 500) : 'Fel från Hugging Face.',
+        raw: rawText ? rawText.slice(0, 2000) : undefined,
       });
     }
 
-    return res.status(200).json(content);
+    if (parseError) {
+      if (rawText.trim().toLowerCase() === 'not found') {
+        return res.status(404).json({
+          error: 'Hugging Face svarade "Not Found" – kontrollera modellnamn eller åtkomst.',
+          raw: rawText.slice(0, 2000),
+        });
+      }
+      throw parseError;
+    }
+
+    return res.status(200).json({
+      data: content,
+      raw: rawText,
+      contentType,
+    });
   } catch (error) {
     console.error('Proxyfel:', error);
     const statusCode = error instanceof JsonParseError ? 502 : 500;
     const message = error instanceof JsonParseError ? error.message : 'Oväntat fel i proxyn.';
-    return res.status(statusCode).json({ error: message });
+    return res.status(statusCode).json({
+      error: message,
+      raw: error instanceof JsonParseError && error.raw ? error.raw.slice(0, 2000) : undefined,
+    });
   }
 });
 
-class JsonParseError extends Error {}
+class JsonParseError extends Error {
+  constructor(message, raw) {
+    super(message);
+    this.name = 'JsonParseError';
+    this.raw = raw;
+  }
+}
 
 function safeJsonParse(text) {
   try {
     return JSON.parse(text);
   } catch (err) {
-    throw new JsonParseError('Kunde inte tolka svaret från Hugging Face.');
+    const streamed = tryParseEventStream(text);
+    if (streamed !== null) {
+      return streamed;
+    }
+    throw new JsonParseError('Kunde inte tolka svaret från Hugging Face.', text);
   }
+}
+
+function tryRecoverInlineJson(text) {
+  if (typeof text !== 'string') {
+    return null;
+  }
+
+  const candidates = [];
+
+  const objectStart = text.indexOf('{');
+  const objectEnd = text.lastIndexOf('}');
+  if (objectStart !== -1 && objectEnd !== -1 && objectEnd > objectStart) {
+    candidates.push(text.slice(objectStart, objectEnd + 1));
+  }
+
+  const arrayStart = text.indexOf('[');
+  const arrayEnd = text.lastIndexOf(']');
+  if (arrayStart !== -1 && arrayEnd !== -1 && arrayEnd > arrayStart) {
+    candidates.push(text.slice(arrayStart, arrayEnd + 1));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch (err) {
+      // ignore candidate and keep trying
+    }
+  }
+
+  return null;
+}
+
+function tryParseEventStream(text) {
+  if (typeof text !== 'string' || !text.trim()) {
+    return null;
+  }
+
+  const lines = text.split(/\r?\n/);
+  const jsonCandidates = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed === 'data: [DONE]') {
+      continue;
+    }
+    if (trimmed.startsWith('data:')) {
+      const payload = trimmed.slice(5).trim();
+      if (payload) {
+        jsonCandidates.push(payload);
+      }
+    }
+  }
+
+  for (let i = jsonCandidates.length - 1; i >= 0; i -= 1) {
+    const candidate = jsonCandidates[i];
+    try {
+      return JSON.parse(candidate);
+    } catch (err) {
+      // Ignorera och prova nästa kandidat
+    }
+  }
+
+  return null;
 }
 
 const PORT = process.env.PORT || 3000;

--- a/hf-tuner.js
+++ b/hf-tuner.js
@@ -151,20 +151,59 @@ export function createAITuner(options = {}) {
 
     if (!response.ok) {
       const text = await response.text();
-      throw new Error(`Proxy ${response.status}: ${text.slice(0, 200)}`);
+      let parsedError = null;
+      try {
+        parsedError = JSON.parse(text);
+      } catch (parseErr) {
+        // ignore – handled generically below
+      }
+
+      const baseMessage = parsedError?.error || text || 'Okänt fel från proxyn';
+      const rawPayload = typeof parsedError?.raw === 'string' ? parsedError.raw : '';
+      if (rawPayload) {
+        console.error('[hf-tuner] Proxy råsvar (fel):', rawPayload);
+      }
+      throw new Error(`Proxy ${response.status}: ${baseMessage}`);
     }
 
-    const data = await response.json();
-    if (data?.error) {
-      throw new Error(`Proxy error: ${data.error}`);
+    const payload = await response.json();
+    if (payload?.error) {
+      const baseMessage = payload.error;
+      const rawDetails = typeof payload.raw === 'string' && payload.raw ? payload.raw : '';
+      if (rawDetails) {
+        console.error('[hf-tuner] Proxy råsvar (fel):', rawDetails);
+      }
+      throw new Error(`Proxy error: ${baseMessage}`);
     }
+
+    const rawText = typeof payload?.raw === 'string' ? payload.raw : '';
+    if (rawText) {
+      console.log('[hf-tuner] Hugging Face råsvar:', rawText);
+    }
+
+    if (payload?.contentType) {
+      console.log('[hf-tuner] Hugging Face content-type:', payload.contentType);
+    }
+
+    const data = payload?.data ?? payload;
 
     const primary = Array.isArray(data) ? data[0] : data;
     const text = primary?.generated_text ?? primary?.output_text ?? primary?.content ?? '';
 
-    const parsed = extractJsonPayload(text);
-    if (!parsed) {
-      throw new Error('Saknar giltigt JSON-svar från modellen.');
+    let parsed = extractJsonPayload(text);
+    if (Array.isArray(parsed)) {
+      parsed = parsed[0];
+    }
+    if (!parsed || typeof parsed !== 'object') {
+      const fallback = extractJsonPayload(rawText);
+      const normalizedFallback = Array.isArray(fallback) ? fallback[0] : fallback;
+      if (normalizedFallback && typeof normalizedFallback === 'object') {
+        parsed = normalizedFallback;
+        console.warn('[hf-tuner] JSON extraherat från råsvar efter fallback.');
+      } else {
+        const snippet = rawText ? ` Rådata: ${rawText.slice(0, 200)}` : '';
+        throw new Error(`Saknar giltigt JSON-svar från modellen.${snippet}`);
+      }
     }
 
     const rewardResult = typeof applyRewardConfig === 'function'


### PR DESCRIPTION
## Summary
- attempt to recover inline JSON snippets from Hugging Face responses before surfacing parse errors
- surface raw Hugging Face text and content-type details back to the client, including a friendly 404 path for "Not Found"
- enhance the tuner to log proxy raw payloads on failures and note the upstream content type for debugging

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4dab9988483248c97de9551b625a9