### PR TITLE
Update default HF tuner model to Zephyr

### DIFF
--- a/hf-tuner.js
+++ b/hf-tuner.js
@@ -1,5 +1,5 @@
 const PROXY_PATH = '/api/proxy';
-const DEFAULT_MODEL_ID = 'mistralai/Mistral-7B-Instruct-v0.3';
+const DEFAULT_MODEL_ID = 'HuggingFaceH4/zephyr-7b-beta';
 
 const SYSTEM_PROMPT = `Du är en expert på reinforcement learning.
 Ditt mål är att justera Snake-MLs belöningsparametrar och centrala


### PR DESCRIPTION
## Summary
- switch the Hugging Face tuner default model to HuggingFaceH4/zephyr-7b-beta so it matches the model actually in use

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4f63890ec8324bc14f6742a94b174