### PR TITLE
Allow GitHub Pages to call proxy via CORS preflight

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -23,8 +23,14 @@ Svara **endast** med en enda rad giltig JSON utan någon extra text eller förkl
 
 const app = express();
 
+const corsOptions = {
+  origin: 'https://nomarcus.github.io',
+  methods: ['POST', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+};
 
-app.use(cors({ origin: 'https://nomarcus.github.io' }));
+app.use(cors(corsOptions));
+app.options('/api/proxy', cors(corsOptions));
 app.use(express.json({ limit: '1mb' }));
 
 


### PR DESCRIPTION
## Summary
- add shared CORS configuration for the proxy server
- explicitly handle OPTIONS preflight requests for the /api/proxy endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d502c854088324a7f851c8cf5bd365