### PR TITLE
Fix Hugging Face proxy base URL

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -4,7 +4,9 @@ import cors from 'cors';
 import fetch from 'node-fetch';
 
 
-const HF_BASE_URL = 'https://huggingface.co/models';
+const HF_BASE_URL =
+  (process.env.HF_BASE_URL && process.env.HF_BASE_URL.trim().replace(/\/+$/, '')) ||
+  'https://api-inference.huggingface.co/models';
 const DEFAULT_MODEL_ID =
   (process.env.HF_MODEL_ID && process.env.HF_MODEL_ID.trim()) ||
   'HuggingFaceH4/zephyr-7b-beta';


### PR DESCRIPTION
## Summary
- update the Hugging Face proxy to default to the inference API base URL
- allow overriding the base URL via an HF_BASE_URL environment variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d503f71504832487901b4f18584cb9