### PR TITLE
Update Hugging Face API URL

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -3,6 +3,9 @@ import express from 'express';
 import cors from 'cors';
 import fetch from 'node-fetch';
 
+const HF_API_URL =
+  'https://api-inference.huggingface.co/models/Qwen/Qwen2-7B-Instruct';
+
 
 const HF_BASE_URL =
   (process.env.HF_BASE_URL && process.env.HF_BASE_URL.trim().replace(/\/+$/, '')) ||


### PR DESCRIPTION
## Summary
- set the Hugging Face API URL constant to the free Qwen/Qwen2-7B-Instruct endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d507b8250083249c53fcd7fb4b9de1