### PR TITLE
Update Hugging Face default model for proxy

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -12,7 +12,7 @@ const HF_BASE_URL =
   'https://api-inference.huggingface.co/models';
 const DEFAULT_MODEL_ID =
   (process.env.HF_MODEL_ID && process.env.HF_MODEL_ID.trim()) ||
-  'HuggingFaceH4/zephyr-7b-beta';
+  'Qwen/Qwen2-7B-Instruct';
 
 
 const SYSTEM_PROMPT = `Du är en expert på reinforcement learning.

--- a/hf-tuner.js
+++ b/hf-tuner.js
@@ -1,5 +1,5 @@
 const PROXY_PATH = '/api/proxy';
-const DEFAULT_MODEL_ID = 'HuggingFaceH4/zephyr-7b-beta';
+const DEFAULT_MODEL_ID = 'Qwen/Qwen2-7B-Instruct';
 
 const SYSTEM_PROMPT = `Du är en expert på reinforcement learning.
 Ditt mål är att justera Snake-MLs belöningsparametrar och centrala


### PR DESCRIPTION
## Summary
- switch the Hugging Face default model used by the tuner to Qwen/Qwen2-7B-Instruct
- apply the same default change in the Express proxy so backend and frontend stay aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d509c69bbc83248429f0bfd0a53bff