### PR TITLE
Update default HF model to Qwen1.5-7B-Chat

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -3,7 +3,7 @@ import express from 'express';
 import fetch from 'node-fetch';
 
 const HF_API_URL =
-  'https://api-inference.huggingface.co/models/Qwen/Qwen2-7B-Instruct';
+  'https://api-inference.huggingface.co/models/Qwen/Qwen1.5-7B-Chat';
 
 
 const HF_BASE_URL =
@@ -11,7 +11,7 @@ const HF_BASE_URL =
   'https://api-inference.huggingface.co/models';
 const DEFAULT_MODEL_ID =
   (process.env.HF_MODEL_ID && process.env.HF_MODEL_ID.trim()) ||
-  'Qwen/Qwen2-7B-Instruct';
+  'Qwen/Qwen1.5-7B-Chat';
 
 
 const SYSTEM_PROMPT = `Du är en expert på reinforcement learning.

--- a/hf-tuner.js
+++ b/hf-tuner.js
@@ -1,5 +1,5 @@
 const PROXY_PATH = '/api/proxy';
-const DEFAULT_MODEL_ID = 'Qwen/Qwen2-7B-Instruct';
+const DEFAULT_MODEL_ID = 'Qwen/Qwen1.5-7B-Chat';
 
 const SYSTEM_PROMPT = `Du är en expert på reinforcement learning.
 Ditt mål är att justera Snake-MLs belöningsparametrar och centrala


### PR DESCRIPTION
## Summary
- update the Hugging Face API endpoint to use Qwen/Qwen1.5-7B-Chat
- align the client-side default model ID with the new model

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d50d81ff248324a9cbd7e9a89e5e8d