### PR TITLE
Ensure proxy server listens on provided port

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -133,6 +133,11 @@ app.post('/api/proxy', async (req, res) => {
   }
 });
 
+const port = resolvePort(process.env.PORT);
+app.listen(port, '0.0.0.0', () => {
+  console.log(`Proxyserver lyssnar på port ${port}`);
+});
+
 function buildUserContent({ telemetry, instruction }) {
   const parts = [];
   if (typeof instruction === 'string' && instruction.trim()) {
@@ -279,6 +284,15 @@ function extractErrorMessage(parsed) {
   }
 
   return '';
+}
+
+function resolvePort(candidate) {
+  const parsed = Number.parseInt(candidate ?? '', 10);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+
+  return 3001;
 }
 
 export default app;

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "start": "node api/proxy.js",
     "train": "node train.js"
   },
   "dependencies": {
     "@tensorflow/tfjs-node": "^4.20.0",
     "express": "^4.19.2",
     "node-fetch": "^3.3.2"
-
   }
 }


### PR DESCRIPTION
## Summary
- start the Express proxy using the port from the environment with a fallback
- expose a helper for resolving the port to keep behaviour predictable on Render
- add an npm start script pointing at the proxy entrypoint for local and Render use

## Testing
- PORT=4000 npm start

------
https://chatgpt.com/codex/tasks/task_e_68d53690e9808324a7d2955a46b10e08