### PR TITLE
Require passcode to enable AI auto-tune

### DIFF
--- a/index.html
+++ b/index.html
@@ -3524,6 +3524,15 @@ function bindUI(){
     updateAiIntervalReadout();
   });
   ui.aiAutoTuneToggle?.addEventListener('change',()=>{
+    if(ui.aiAutoTuneToggle.checked){
+      const code=prompt('Ange säkerhetskod för att aktivera AI Auto-Tune:');
+      if(code!=='1234554321'){
+        ui.aiAutoTuneToggle.checked=false;
+        aiAutoTuneEnabled=false;
+        flash('Fel kod. AI Auto-Tune förblir avstängd.',true);
+        return;
+      }
+    }
     aiAutoTuneEnabled=ui.aiAutoTuneToggle.checked;
     if(aiTuner) aiTuner.setEnabled(aiAutoTuneEnabled);
     const detail=aiAutoTuneEnabled?'Aktiverad':'Avstängd';


### PR DESCRIPTION
## Summary
- prompt for a security code before allowing AI Auto-Tune to be enabled
- block activation and show an error flash message when the code 1234554321 is not entered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59562b52c8324a008e8d437cfa556