### PR TITLE
Handle telemetry crash synonyms and new stats fields

### DIFF
--- a/ai-tuner.js
+++ b/ai-tuner.js
@@ -82,6 +82,26 @@ function describeTrend(value,positiveWord='rising',negativeWord='falling',zeroWo
   return value>0?`${positiveWord} by ${magnitude}`:`${negativeWord} by ${magnitude}`;
 }
 
+const CRASH_SYNONYMS={
+  wall:'wall',
+  'hit wall':'wall',
+  'wall collision':'wall',
+  'wall-hit':'wall',
+  self:'self',
+  'self collision':'self',
+  'hit self':'self',
+  tail:'self',
+  timeout:'timeout',
+  'timed out':'timeout',
+  'time out':'timeout',
+  'time-out':'timeout',
+  enemy:'enemy',
+  'hit enemy':'enemy',
+  'enemy collision':'enemy',
+  none:'none',
+  'no crash':'none',
+};
+
 const CRASH_LABELS={
   wall:'wall hits',
   self:'self collisions',
@@ -90,18 +110,64 @@ const CRASH_LABELS={
   none:'no crash',
 };
 
-function humanizeCrash(key){
+function normaliseCrashKey(key){
   if(!key) return '';
-  return CRASH_LABELS[key]||key.replace(/_/g,' ');
+  const raw=String(key).toLowerCase().trim();
+  if(!raw) return '';
+  return CRASH_SYNONYMS[raw]||raw.replace(/\s+/g,'_');
+}
+
+function humanizeCrash(key){
+  const normalised=normaliseCrashKey(key);
+  if(!normalised) return '';
+  return CRASH_LABELS[normalised]||normalised.replace(/_/g,' ');
+}
+
+function aggregateCrashCounts(crashCounts={}){
+  if(!crashCounts||typeof crashCounts!=='object') return null;
+  const aggregated={};
+  for(const [key,value] of Object.entries(crashCounts)){
+    const numeric=Number(value);
+    if(!Number.isFinite(numeric)||numeric<=0) continue;
+    const normalised=normaliseCrashKey(key);
+    if(!normalised) continue;
+    aggregated[normalised]=(aggregated[normalised]||0)+numeric;
+  }
+  return Object.keys(aggregated).length?aggregated:null;
 }
 
 function selectDominantCrash(crashCounts={},totalEpisodes=0){
-  const entries=Object.entries(crashCounts).filter(([,count])=>Number.isFinite(count)&&count>0);
-  if(!entries.length) return null;
+  const aggregated=aggregateCrashCounts(crashCounts);
+  if(!aggregated) return null;
+  const entries=Object.entries(aggregated);
   entries.sort((a,b)=>b[1]-a[1]);
   const [key,count]=entries[0];
   const share=totalEpisodes>0?Math.round((count/totalEpisodes)*100):null;
   return {key,count,share};
+}
+
+function extractCrashCounts(telemetry){
+  if(!telemetry||typeof telemetry!=='object') return null;
+  const direct=telemetry.crash;
+  if(direct&&typeof direct==='object'){
+    return direct;
+  }
+  const nested=telemetry.stats?.crashCounts;
+  if(nested&&typeof nested==='object'){
+    return nested;
+  }
+  const candidates=[
+    telemetry.gameStats?.crashReason,
+    telemetry.stats?.lastCrash,
+    telemetry.lastCrash,
+    telemetry.meta?.lastCrash,
+  ];
+  for(const reason of candidates){
+    if(typeof reason==='string'&&reason.trim()){
+      return {[reason]:1};
+    }
+  }
+  return null;
 }
 
 function summariseChangeList(changes=[],maxItems=3){
@@ -140,24 +206,44 @@ function buildAnalysisParagraph({telemetry,response,rewardChanges=[],hyperChange
   if(!telemetry||typeof telemetry!=='object'||!response) return '';
   const meta=telemetry.meta||{};
   const stats=telemetry.stats||{};
-  const interval=Number(meta.interval)||0;
-  const episode=Number(meta.episode)||0;
+  const trend=telemetry.trendAnalysis||{};
+  const game=telemetry.gameStats||{};
+  const interval=Number(meta.interval??meta.window??trend.window)||0;
+  const episode=Number(meta.episode??meta.latestEpisode??meta.currentEpisode)||0;
   const startEpisode=interval&&episode?Math.max(1,episode-interval+1):null;
-  const spanText=interval&&episode?`Last ${interval} episodes (${startEpisode}–${episode})`:'Recent episodes';
-  const rewardAvgText=Number.isFinite(stats.rewardAvg)?stats.rewardAvg.toFixed(2):'n/a';
-  const rewardTrendText=describeTrend(stats.rewardTrend,'rising','falling','flat');
-  const fruitTrendDescriptor=Number.isFinite(stats.fruitTrend)?describeTrend(stats.fruitTrend,'growing','shrinking','flat'):'flat';
-  const bestLen=Number.isFinite(meta.best)?meta.best:null;
-
-  const observationSentence=ensureSentence(
-    `${spanText} show average reward ${rewardAvgText} with a ${rewardTrendText} trend, while fruit momentum is ${fruitTrendDescriptor}`+
-    (bestLen?` and best length reached ${bestLen}`:'')
-  );
-
-  const stepsAvg=Number.isFinite(stats.stepsAvg)?Math.round(stats.stepsAvg):null;
+  const spanText=interval&&episode?`Last ${interval} episodes (${startEpisode}–${episode})`:interval?`Last ${interval} episodes`:episode?`Up to episode ${episode}`:'Recent episodes';
+  const rewardAvg=Number.isFinite(stats.rewardAvg)?stats.rewardAvg:Number.isFinite(trend.avgReward)?trend.avgReward:null;
+  const rewardTrendValue=Number.isFinite(stats.rewardTrend)?stats.rewardTrend:Number.isFinite(trend.rewardTrend)?trend.rewardTrend:null;
+  const rewardTrendText=rewardTrendValue!==null?describeTrend(rewardTrendValue,'rising','falling','flat'):null;
+  const fruitTrendValue=Number.isFinite(stats.fruitTrend)?stats.fruitTrend:Number.isFinite(trend.fruitTrend)?trend.fruitTrend:null;
+  const fruitTrendDescriptor=fruitTrendValue!==null?describeTrend(fruitTrendValue,'growing','shrinking','flat'):typeof trend.scoreTrend==='string'?trend.scoreTrend:'flat';
+  const bestLen=Number.isFinite(meta.best)?meta.best:Number.isFinite(meta.currentHighScore)?meta.currentHighScore:null;
+  const observationParts=[];
+  if(rewardAvg!==null){
+    const avgText=rewardAvg.toFixed(2);
+    const trendText=rewardTrendText||'steady';
+    observationParts.push(`average reward ${avgText} with a ${trendText} trend`);
+  }
+  if(fruitTrendDescriptor){
+    observationParts.push(`fruit momentum ${fruitTrendDescriptor}`);
+  }
+  if(!observationParts.length&&typeof trend.scoreTrend==='string'&&trend.scoreTrend.trim()){
+    observationParts.push(`score trend ${trend.scoreTrend.trim()}`);
+  }
+  if(!observationParts.length&&Number.isFinite(game.fruitsEaten)){
+    observationParts.push(`latest fruits ${game.fruitsEaten}`);
+  }
+  let observationSentence=observationParts.length?ensureSentence(`${spanText} show ${observationParts.join(', ')}`):ensureSentence(`${spanText} are reported without aggregate reward metrics`);
+  if(bestLen){
+    const suffix=observationSentence.endsWith('.')?observationSentence.slice(0,-1):observationSentence;
+    observationSentence=ensureSentence(`${suffix} and best length reached ${bestLen}`);
+  }
+  const stepsAvg=Number.isFinite(stats.stepsAvg)?Math.round(stats.stepsAvg):Number.isFinite(trend.avgStepsPerGame)?Math.round(trend.avgStepsPerGame):Number.isFinite(game.steps)?Math.round(game.steps):null;
   const loopsAvg=Number.isFinite(stats.loopsAvg)?stats.loopsAvg.toFixed(2):null;
-  const fruitRate=Number.isFinite(stats.fruitRate)?stats.fruitRate.toFixed(3):null;
-  const dominantCrash=selectDominantCrash(telemetry.crash,interval||telemetry.meta?.interval||rewardChanges.length+hyperChanges.length);
+  const fruitRate=Number.isFinite(stats.fruitRate)?stats.fruitRate.toFixed(3):Number.isFinite(game.fruitsEaten)&&Number.isFinite(game.steps)&&game.steps>0?(game.fruitsEaten/game.steps).toFixed(3):null;
+  const crashCounts=extractCrashCounts(telemetry);
+  const totalEpisodesForCrash=interval||telemetry.meta?.interval||0;
+  const dominantCrash=crashCounts?selectDominantCrash(crashCounts,totalEpisodesForCrash):null;
   const crashText=dominantCrash&&dominantCrash.share!==null?`${humanizeCrash(dominantCrash.key)} at ${dominantCrash.share}%`:(dominantCrash?humanizeCrash(dominantCrash.key):'');
   const trendParts=[];
   if(stepsAvg!==null) trendParts.push(`mean steps ${stepsAvg}`);
@@ -165,17 +251,14 @@ function buildAnalysisParagraph({telemetry,response,rewardChanges=[],hyperChange
   if(fruitRate!==null) trendParts.push(`fruit rate ${fruitRate} per step`);
   if(crashText) trendParts.push(`dominant exit ${crashText}`);
   const trendsSentence=trendParts.length?ensureSentence(`Telemetry also notes ${trendParts.join(', ')}.`):'';
-
   const rewardDescriptions=summariseChangeList(rewardChanges);
   const hyperDescriptions=summariseChangeList(hyperChanges);
   const adjustmentParts=[];
   if(rewardDescriptions.length) adjustmentParts.push(`reward tweaks ${rewardDescriptions.join('; ')}`);
   if(hyperDescriptions.length) adjustmentParts.push(`hyperparameter updates ${hyperDescriptions.join('; ')}`);
   const adjustmentsSentence=adjustmentParts.length?ensureSentence(`Adjustments apply ${adjustmentParts.join(' and ')}.`):'';
-
   const reasoningSnippet=extractReasoningSnippet(response);
   const reasoningSentence=reasoningSnippet?ensureSentence(`Rationale: ${reasoningSnippet}`):'';
-
   const statusMap={
     good:'is going well',
     stable:'is stable',
@@ -183,7 +266,7 @@ function buildAnalysisParagraph({telemetry,response,rewardChanges=[],hyperChange
     uncertain:'needs closer monitoring',
   };
   const statusKey=response.assessment?.status;
-  const defaultStatus=stats.rewardTrend>0.01?'is going well':stats.rewardTrend<-0.01?'needs improvement':'is stable';
+  const defaultStatus=rewardTrendValue>0.01?'is going well':rewardTrendValue<-0.01?'needs improvement':'is stable';
   const statusText=statusMap[statusKey]||defaultStatus;
   const trendWord=response.assessment?.trend;
   const confidence=Number.isFinite(response.assessment?.confidence)?Math.round(response.assessment.confidence*100):null;
@@ -191,15 +274,16 @@ function buildAnalysisParagraph({telemetry,response,rewardChanges=[],hyperChange
   if(trendWord) assessmentParts.push(`trend looks ${trendWord}`);
   if(confidence!==null) assessmentParts.push(`confidence ${confidence}%`);
   const assessmentSentence=ensureSentence(assessmentParts.join(', '));
-
   const sentences=[observationSentence,trendsSentence,adjustmentsSentence,reasoningSentence,assessmentSentence].filter(Boolean);
   let text=sentences.join(' ');
   let totalWords=wordCount(text);
-
   if(totalWords<80){
     const extras=[];
     if(Number.isFinite(stats.timeToFruit)) extras.push(`mean time-to-fruit ${stats.timeToFruit.toFixed(1)} moves`);
+    if(Number.isFinite(trend.recentDeaths)) extras.push(`recent deaths ${trend.recentDeaths}`);
+    if(typeof game.currentDirection==='string'&&game.currentDirection.trim()) extras.push(`current direction ${game.currentDirection.trim()}`);
     if(Number.isFinite(meta.envs)&&meta.envs>0) extras.push(`${meta.envs} environments active`);
+    if(Number.isFinite(game.steps)) extras.push(`latest steps ${Math.round(game.steps)}`);
     const breakdown=telemetry.rewardBreakdown;
     if(breakdown&&typeof breakdown==='object'){
       const entries=Object.entries(breakdown)
@@ -215,7 +299,6 @@ function buildAnalysisParagraph({telemetry,response,rewardChanges=[],hyperChange
       totalWords=wordCount(text);
     }
   }
-
   if(totalWords>120&&reasoningSentence){
     const trimmedReason=ensureSentence(`Rationale: ${limitWords(reasoningSnippet,25)}`);
     const idx=sentences.indexOf(reasoningSentence);
@@ -225,11 +308,9 @@ function buildAnalysisParagraph({telemetry,response,rewardChanges=[],hyperChange
       totalWords=wordCount(text);
     }
   }
-
   if(totalWords>120){
     text=limitWords(text,120);
   }
-
   return text.trim();
 }
 

--- a/hf-tuner.js
+++ b/hf-tuner.js
@@ -139,6 +139,26 @@ function describeTrend(value, positiveWord = 'rising', negativeWord = 'falling',
   return value > 0 ? `${positiveWord} by ${magnitude}` : `${negativeWord} by ${magnitude}`;
 }
 
+const CRASH_SYNONYMS = {
+  wall: 'wall',
+  'hit wall': 'wall',
+  'wall collision': 'wall',
+  'wall-hit': 'wall',
+  self: 'self',
+  'self collision': 'self',
+  'hit self': 'self',
+  tail: 'self',
+  timeout: 'timeout',
+  'timed out': 'timeout',
+  'time out': 'timeout',
+  'time-out': 'timeout',
+  enemy: 'enemy',
+  'hit enemy': 'enemy',
+  'enemy collision': 'enemy',
+  none: 'none',
+  'no crash': 'none',
+};
+
 const CRASH_LABELS = {
   wall: 'wall hits',
   self: 'self collisions',
@@ -147,19 +167,64 @@ const CRASH_LABELS = {
   none: 'no crash',
 };
 
-function humanizeCrash(key) {
+function normaliseCrashKey(key) {
   if (!key) return '';
-  return CRASH_LABELS[key] || key.replace(/_/g, ' ');
+  const raw = String(key).toLowerCase().trim();
+  if (!raw) return '';
+  return CRASH_SYNONYMS[raw] || raw.replace(/\s+/g, '_');
+}
+
+function humanizeCrash(key) {
+  const normalised = normaliseCrashKey(key);
+  if (!normalised) return '';
+  return CRASH_LABELS[normalised] || normalised.replace(/_/g, ' ');
+}
+
+function aggregateCrashCounts(crashCounts = {}) {
+  if (!crashCounts || typeof crashCounts !== 'object') return null;
+  const aggregated = {};
+  for (const [key, value] of Object.entries(crashCounts)) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= 0) continue;
+    const normalised = normaliseCrashKey(key);
+    if (!normalised) continue;
+    aggregated[normalised] = (aggregated[normalised] || 0) + numeric;
+  }
+  return Object.keys(aggregated).length ? aggregated : null;
 }
 
 function selectDominantCrash(crashCounts = {}, totalEpisodes = 0) {
-  const entries = Object.entries(crashCounts)
-    .filter(([, count]) => Number.isFinite(count) && count > 0);
-  if (!entries.length) return null;
+  const aggregated = aggregateCrashCounts(crashCounts);
+  if (!aggregated) return null;
+  const entries = Object.entries(aggregated);
   entries.sort((a, b) => b[1] - a[1]);
   const [key, count] = entries[0];
   const share = totalEpisodes > 0 ? Math.round((count / totalEpisodes) * 100) : null;
   return { key, count, share };
+}
+
+function extractCrashCounts(telemetry) {
+  if (!telemetry || typeof telemetry !== 'object') return null;
+  const direct = telemetry.crash;
+  if (direct && typeof direct === 'object') {
+    return direct;
+  }
+  const nested = telemetry.stats?.crashCounts;
+  if (nested && typeof nested === 'object') {
+    return nested;
+  }
+  const candidates = [
+    telemetry.gameStats?.crashReason,
+    telemetry.stats?.lastCrash,
+    telemetry.lastCrash,
+    telemetry.meta?.lastCrash,
+  ];
+  for (const reason of candidates) {
+    if (typeof reason === 'string' && reason.trim()) {
+      return { [reason]: 1 };
+    }
+  }
+  return null;
 }
 
 function summariseChangeList(changes = [], maxItems = 3) {
@@ -198,33 +263,97 @@ function buildAnalysisParagraph({ telemetry, response, rewardChanges = [], hyper
   if (!telemetry || typeof telemetry !== 'object' || !response) return '';
   const meta = telemetry.meta || {};
   const stats = telemetry.stats || {};
-  const interval = Number(meta.interval) || 0;
-  const episode = Number(meta.episode) || 0;
+  const trend = telemetry.trendAnalysis || {};
+  const game = telemetry.gameStats || {};
+  const interval = Number(meta.interval ?? meta.window ?? trend.window) || 0;
+  const episode = Number(meta.episode ?? meta.latestEpisode ?? meta.currentEpisode) || 0;
   const startEpisode = interval && episode ? Math.max(1, episode - interval + 1) : null;
   const spanText = interval && episode
     ? `Last ${interval} episodes (${startEpisode}–${episode})`
-    : 'Recent episodes';
-  const rewardAvgText = Number.isFinite(stats.rewardAvg) ? stats.rewardAvg.toFixed(2) : 'n/a';
-  const rewardTrendText = describeTrend(stats.rewardTrend, 'rising', 'falling', 'flat');
-  const fruitTrendDescriptor = Number.isFinite(stats.fruitTrend)
-    ? describeTrend(stats.fruitTrend, 'growing', 'shrinking', 'flat')
-    : 'flat';
-  const bestLen = Number.isFinite(meta.best) ? meta.best : null;
+    : interval
+      ? `Last ${interval} episodes`
+      : episode
+        ? `Up to episode ${episode}`
+        : 'Recent episodes';
 
-  const observationSentence = ensureSentence(
-    `${spanText} show average reward ${rewardAvgText} with a ${rewardTrendText} trend, while fruit momentum is ${fruitTrendDescriptor}` +
-      (bestLen ? ` and best length reached ${bestLen}` : '')
-  );
+  const rewardAvg = Number.isFinite(stats.rewardAvg)
+    ? stats.rewardAvg
+    : Number.isFinite(trend.avgReward)
+      ? trend.avgReward
+      : null;
+  const rewardTrendValue = Number.isFinite(stats.rewardTrend)
+    ? stats.rewardTrend
+    : Number.isFinite(trend.rewardTrend)
+      ? trend.rewardTrend
+      : null;
+  const rewardTrendText = rewardTrendValue !== null
+    ? describeTrend(rewardTrendValue, 'rising', 'falling', 'flat')
+    : null;
 
-  const stepsAvg = Number.isFinite(stats.stepsAvg) ? Math.round(stats.stepsAvg) : null;
+  const fruitTrendValue = Number.isFinite(stats.fruitTrend)
+    ? stats.fruitTrend
+    : Number.isFinite(trend.fruitTrend)
+      ? trend.fruitTrend
+      : null;
+  const fruitTrendDescriptor = fruitTrendValue !== null
+    ? describeTrend(fruitTrendValue, 'growing', 'shrinking', 'flat')
+    : typeof trend.scoreTrend === 'string'
+      ? trend.scoreTrend
+      : 'flat';
+
+  const bestLen = Number.isFinite(meta.best)
+    ? meta.best
+    : Number.isFinite(meta.currentHighScore)
+      ? meta.currentHighScore
+      : null;
+
+  const observationParts = [];
+  if (rewardAvg !== null) {
+    const avgText = rewardAvg.toFixed(2);
+    const trendText = rewardTrendText || 'steady';
+    observationParts.push(`average reward ${avgText} with a ${trendText} trend`);
+  }
+  if (fruitTrendDescriptor) {
+    observationParts.push(`fruit momentum ${fruitTrendDescriptor}`);
+  }
+  if (!observationParts.length && typeof trend.scoreTrend === 'string' && trend.scoreTrend.trim()) {
+    observationParts.push(`score trend ${trend.scoreTrend.trim()}`);
+  }
+  if (!observationParts.length && Number.isFinite(game.fruitsEaten)) {
+    observationParts.push(`latest fruits ${game.fruitsEaten}`);
+  }
+
+  let observationSentence = observationParts.length
+    ? ensureSentence(`${spanText} show ${observationParts.join(', ')}`)
+    : ensureSentence(`${spanText} are reported without aggregate reward metrics`);
+  if (bestLen) {
+    const suffix = observationSentence.endsWith('.') ? observationSentence.slice(0, -1) : observationSentence;
+    observationSentence = ensureSentence(`${suffix} and best length reached ${bestLen}`);
+  }
+
+  const stepsAvg = Number.isFinite(stats.stepsAvg)
+    ? Math.round(stats.stepsAvg)
+    : Number.isFinite(trend.avgStepsPerGame)
+      ? Math.round(trend.avgStepsPerGame)
+      : Number.isFinite(game.steps)
+        ? Math.round(game.steps)
+        : null;
   const loopsAvg = Number.isFinite(stats.loopsAvg) ? stats.loopsAvg.toFixed(2) : null;
-  const fruitRate = Number.isFinite(stats.fruitRate) ? stats.fruitRate.toFixed(3) : null;
-  const dominantCrash = selectDominantCrash(telemetry.crash, interval || telemetry.meta?.interval || rewardChanges.length + hyperChanges.length);
+  const fruitRate = Number.isFinite(stats.fruitRate)
+    ? stats.fruitRate.toFixed(3)
+    : Number.isFinite(game.fruitsEaten) && Number.isFinite(game.steps) && game.steps > 0
+      ? (game.fruitsEaten / game.steps).toFixed(3)
+      : null;
+
+  const crashCounts = extractCrashCounts(telemetry);
+  const totalEpisodesForCrash = interval || telemetry.meta?.interval || 0;
+  const dominantCrash = crashCounts ? selectDominantCrash(crashCounts, totalEpisodesForCrash) : null;
   const crashText = dominantCrash && dominantCrash.share !== null
     ? `${humanizeCrash(dominantCrash.key)} at ${dominantCrash.share}%`
     : dominantCrash
       ? humanizeCrash(dominantCrash.key)
       : '';
+
   const trendParts = [];
   if (stepsAvg !== null) trendParts.push(`mean steps ${stepsAvg}`);
   if (loopsAvg !== null) trendParts.push(`loop hits ${loopsAvg}`);
@@ -255,7 +384,7 @@ function buildAnalysisParagraph({ telemetry, response, rewardChanges = [], hyper
     uncertain: 'needs closer monitoring',
   };
   const statusKey = response.assessment?.status;
-  const defaultStatus = stats.rewardTrend > 0.01 ? 'is going well' : stats.rewardTrend < -0.01 ? 'needs improvement' : 'is stable';
+  const defaultStatus = rewardTrendValue > 0.01 ? 'is going well' : rewardTrendValue < -0.01 ? 'needs improvement' : 'is stable';
   const statusText = statusMap[statusKey] || defaultStatus;
   const trendWord = response.assessment?.trend;
   const confidence = Number.isFinite(response.assessment?.confidence)
@@ -282,8 +411,17 @@ function buildAnalysisParagraph({ telemetry, response, rewardChanges = [], hyper
     if (Number.isFinite(stats.timeToFruit)) {
       extras.push(`mean time-to-fruit ${stats.timeToFruit.toFixed(1)} moves`);
     }
+    if (Number.isFinite(trend.recentDeaths)) {
+      extras.push(`recent deaths ${trend.recentDeaths}`);
+    }
+    if (typeof game.currentDirection === 'string' && game.currentDirection.trim()) {
+      extras.push(`current direction ${game.currentDirection.trim()}`);
+    }
     if (Number.isFinite(meta.envs) && meta.envs > 0) {
       extras.push(`${meta.envs} environments active`);
+    }
+    if (Number.isFinite(game.steps)) {
+      extras.push(`latest steps ${Math.round(game.steps)}`);
     }
     const breakdown = telemetry.rewardBreakdown;
     if (breakdown && typeof breakdown === 'object') {


### PR DESCRIPTION
## Summary
- normalise crash reasons like "hit wall" before generating UI summaries in both tuner clients
- fall back to new telemetry fields such as `gameStats` and `trendAnalysis` when building analysis paragraphs
- include additional context (recent deaths, direction, latest steps) when available from updated payloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c1c77b0c83249531efc94da09412