### PR TITLE
Improve JSON parsing robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Dependencies
+node_modules/
+
+# Logs and history files
+api/logs/*.jsonl*
+
+# Environment keys
+__key.js

--- a/hf-tuner.js
+++ b/hf-tuner.js
@@ -476,12 +476,50 @@ function extractJsonPayload(text) {
   const end = text.lastIndexOf('}');
   if (start === -1 || end === -1 || end < start) return null;
   const snippet = text.slice(start, end + 1);
+
   try {
     return JSON.parse(snippet);
   } catch (err) {
-    console.warn('[hf-tuner] kunde inte tolka JSON från modellen', err);
+    const repaired = repairJsonSnippet(snippet);
+    if (repaired !== snippet) {
+      try {
+        return JSON.parse(repaired);
+      } catch (innerErr) {
+        console.warn('[hf-tuner] kunde inte tolka reparerad JSON från modellen', innerErr, {
+          snippet: repaired,
+        });
+      }
+    }
+
+    console.warn('[hf-tuner] kunde inte tolka JSON från modellen', err, { snippet });
     return null;
   }
+}
+
+function repairJsonSnippet(snippet) {
+  if (typeof snippet !== 'string') return snippet;
+
+  let repaired = snippet;
+  let mutated = false;
+
+  const replacements = [
+    [/[“”]/g, '"'],
+    [/[‘’]/g, "'"],
+    [/([{,]\s*)'([^'\\]*?)'\s*:/g, '$1"$2":'],
+    [/([{,]\s*)([A-Za-z0-9_]+)\s*:(?=\s)/g, '$1"$2":'],
+    [/(:\s*)'([^'\\]*(?:\\.[^'\\]*)*)'/g, '$1"$2"'],
+    [/,(\s*[}\]])/g, '$1'],
+  ];
+
+  for (const [pattern, replacement] of replacements) {
+    const updated = repaired.replace(pattern, replacement);
+    if (updated !== repaired) {
+      repaired = updated;
+      mutated = true;
+    }
+  }
+
+  return mutated ? repaired : snippet;
 }
 
 function extractTuningPayload(data, rawText) {


### PR DESCRIPTION
## Summary
- add defensive JSON repair for hf-tuner responses before parsing
- reuse the same repair logic in the proxy API when parsing Groq responses
- add a root .gitignore to ignore logs, credentials, and dependencies

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8d24518d4832483dfef67b76e34c7