### PR TITLE
Clarify tuner prompt with baseline and adjustment heuristics

### DIFF
--- a/ai-tuner.js
+++ b/ai-tuner.js
@@ -8,6 +8,18 @@ Evaluate the agent’s long-term progress and stability.
 
 Suggest specific numeric adjustments to reward settings and key hyperparameters that will increase the chance of consistently reaching the maximum score without overfitting.
 
+When no prior training signal is available, initialise the configuration with:
+- rewardConfig: { fruit: 10, step: -0.01, death: -5, closerToFruit: 0.1, furtherFromFruit: -0.1 }
+- hyper: { learningRate: 0.0007, gamma: 0.99, clipRange: 0.2, entropyCoeff: 0.01, valueCoeff: 0.5, batchSize: 2048, nEpochs: 4, lam: 0.95 }
+- grid: { size: 10 }
+
+Respect these adjustment heuristics:
+- If fruit rate is still 0 after 10k episodes, increase fruit reward (up to 20), reduce death penalty (down to -2), and consider a smaller batch size alongside a higher learning rate.
+- If training oscillates or overfits, reduce the learning rate, increase batch size, or widen the clip range.
+- Keep all reward magnitudes between -10 and +20 and mention any normalisation you apply.
+- Entropy should decay from 0.01–0.02 towards 0.001 once the agent shows sustained improvement.
+- Grow the grid only when performance warrants it: size 15 after avgScore > 5 and fruitRate > 0.5 for 10k episodes, size 20 after avgScore > 10 and fruitRate > 0.6 for 20k episodes, and size 25 after avgScore > 15 and fruitRate > 0.7 for 30k episodes.
+
 Explain your reasoning in 1–2 short paragraphs so a developer can follow your thought process.
 Always respond with valid JSON containing:
 

--- a/hf-tuner.js
+++ b/hf-tuner.js
@@ -7,6 +7,18 @@ Evaluate the agent’s long-term progress and stability.
 
 Suggest specific numeric adjustments to reward settings and key hyperparameters that will increase the chance of consistently reaching the maximum score without overfitting.
 
+When no prior training signal is available, initialise the configuration with:
+- rewardConfig: { fruit: 10, step: -0.01, death: -5, closerToFruit: 0.1, furtherFromFruit: -0.1 }
+- hyper: { learningRate: 0.0007, gamma: 0.99, clipRange: 0.2, entropyCoeff: 0.01, valueCoeff: 0.5, batchSize: 2048, nEpochs: 4, lam: 0.95 }
+- grid: { size: 10 }
+
+Respect these adjustment heuristics:
+- If fruit rate is still 0 after 10k episodes, increase fruit reward (up to 20), reduce death penalty (down to -2), and consider a smaller batch size alongside a higher learning rate.
+- If training oscillates or overfits, reduce the learning rate, increase batch size, or widen the clip range.
+- Keep all reward magnitudes between -10 and +20 and mention any normalisation you apply.
+- Entropy should decay from 0.01–0.02 towards 0.001 once the agent shows sustained improvement.
+- Grow the grid only when performance warrants it: size 15 after avgScore > 5 and fruitRate > 0.5 for 10k episodes, size 20 after avgScore > 10 and fruitRate > 0.6 for 20k episodes, and size 25 after avgScore > 15 and fruitRate > 0.7 for 30k episodes.
+
 Explain your reasoning in 1–2 short paragraphs so a developer can follow your thought process.
 Always respond with valid JSON containing:
 


### PR DESCRIPTION
## Summary
- document baseline reward, hyperparameter, and grid defaults in the tuner system prompt
- add explicit heuristic guidance for reward scaling, entropy decay, and curriculum upgrades to the AI prompts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8db4622648324b4f710e39be07eba