### PR TITLE
Reorganize AI Auto-Tune controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,6 +342,15 @@ button:focus-visible{
   font-size:12px;
   font-weight:600;
 }
+.ai-interval-field .field-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+.ai-interval-field .toggle span{
+  font-size:12px;
+}
 input[type="range"]{
   width:200px;
   -webkit-appearance:none;
@@ -978,27 +987,21 @@ footer{
           <h3>AI Auto-Tune</h3>
           <p class="hint">LLM-analys justerar belöningar och hyperparametrar för att maximera överlevnad och frukt.</p>
         </div>
-        <label class="toggle" for="aiAutoTuneToggle">
-          <input type="checkbox" id="aiAutoTuneToggle" aria-label="Aktivera AI Auto-Tune">
-          <span>Aktivera</span>
-        </label>
       </div>
 
       <div class="ai-auto-tune__controls" role="group" aria-label="AI Auto-Tune inställningar">
         <section class="ai-auto-tune__column" aria-labelledby="aiAutoTuneAiHeading">
           <h4 id="aiAutoTuneAiHeading">AI-analys</h4>
-          <div class="field compact">
-            <label for="aiIntervalSlider">Analysintervall</label>
+          <div class="field compact ai-interval-field">
+            <div class="field-header">
+              <label for="aiIntervalSlider">Analysintervall</label>
+              <label class="toggle" for="aiAutoTuneToggle">
+                <input type="checkbox" id="aiAutoTuneToggle" aria-label="Aktivera AI Auto-Tune">
+                <span>Aktivera</span>
+              </label>
+            </div>
             <input type="range" id="aiIntervalSlider" min="100" max="5000" step="100" value="500">
             <span class="mono" id="aiIntervalReadout">500 ep</span>
-          </div>
-          <div class="field">
-            <span class="hint">Justeringstempo</span>
-            <div class="pill-group" id="aiStyleGroup" role="group" aria-label="Justeringstempo">
-              <button type="button" class="pill" data-style="calm">Lugn</button>
-              <button type="button" class="pill active" data-style="balanced">Medel</button>
-              <button type="button" class="pill" data-style="aggressive">Aggressiv</button>
-            </div>
           </div>
         </section>
         <section class="ai-auto-tune__column" aria-labelledby="aiAutoTuneAutoHeading">
@@ -1007,6 +1010,14 @@ footer{
             <label for="aiRunLimit">Rundor att köra</label>
             <input type="number" id="aiRunLimit" min="0" step="100" inputmode="numeric" placeholder="0">
             <span class="hint" id="aiRunLimitHint">0 = obegränsat</span>
+          </div>
+          <div class="field">
+            <span class="hint">Justeringstempo</span>
+            <div class="pill-group" id="aiStyleGroup" role="group" aria-label="Justeringstempo">
+              <button type="button" class="pill" data-style="calm">Lugn</button>
+              <button type="button" class="pill active" data-style="balanced">Medel</button>
+              <button type="button" class="pill" data-style="aggressive">Aggressiv</button>
+            </div>
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- move the AI Auto-Tune activation toggle into the analysis interval card
- keep the pacing options next to auto-run settings for clearer grouping

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dadb02e9bc832487aa1ec433880df7