### PR TITLE
Refine stage preset UX and preserve training progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -979,6 +979,14 @@ footer{
         <option value="ppo">Proximal Policy Optimization</option>
       </select>
     </div>
+    <div class="field block hidden" id="agentPresetField">
+      <label for="presetSelect">Agent preset</label>
+      <select id="presetSelect"></select>
+    </div>
+    <div class="field block">
+      <label for="stagePresetSelect">Stage preset</label>
+      <select id="stagePresetSelect"></select>
+    </div>
     <p class="hint" id="algoDescription">Prioritized replay, n-step returns, and dueling heads make DQN stable and sample efficient.</p>
 
     <div class="ai-auto-tune" id="aiAutoTunePanel">
@@ -3199,6 +3207,258 @@ const AGENT_PRESETS={
   },
 };
 
+const STAGE_AGENT_ALIASES={ddqn:'dueling',rainbow:'dueling',sac:'ppo'};
+const STAGE_PRESETS={
+  dqn_stage1:{
+    label:'DQN Stage 1 – Warmup',
+    agent:'vanilla',
+    gamma:0.97,lr:0.00025,
+    epsStart:1.0,epsEnd:0.2,epsDecay:60000,
+    batchSize:64,bufferSize:40000,targetSync:1500,
+    nStep:1,hiddenSizes:[128,128],
+    rewardConfig:{fruitReward:12,stepPenalty:0.01,timeoutPenalty:5},
+  },
+  dqn_stage2:{
+    label:'DQN Stage 2 – Exploration Shaping',
+    agent:'vanilla',
+    gamma:0.975,lr:0.00022,
+    epsStart:1.0,epsEnd:0.18,epsDecay:80000,
+    batchSize:96,bufferSize:60000,targetSync:1800,
+    nStep:2,hiddenSizes:[160,160],
+    rewardConfig:{fruitReward:14,stepPenalty:0.0095,timeoutPenalty:4.5},
+  },
+  dqn_stage3:{
+    label:'DQN Stage 3 – Midgame Stabilisation',
+    agent:'vanilla',
+    gamma:0.98,lr:0.00018,
+    epsStart:0.95,epsEnd:0.14,epsDecay:95000,
+    batchSize:128,bufferSize:90000,targetSync:2000,
+    nStep:3,hiddenSizes:[192,192],
+    rewardConfig:{fruitReward:18,stepPenalty:0.008,timeoutPenalty:4},
+  },
+  dqn_stage4:{
+    label:'DQN Stage 4 – Ramp Up',
+    agent:'vanilla',
+    gamma:0.988,lr:0.00013,
+    epsStart:0.9,epsEnd:0.1,epsDecay:115000,
+    batchSize:160,bufferSize:140000,targetSync:2400,
+    nStep:4,hiddenSizes:[224,224,128],
+    rewardConfig:{fruitReward:22,stepPenalty:0.007,timeoutPenalty:3.5},
+  },
+  dqn_stage5:{
+    label:'DQN Stage 5 – Endgame',
+    agent:'vanilla',
+    gamma:0.993,lr:0.0001,
+    epsStart:0.85,epsEnd:0.08,epsDecay:140000,
+    batchSize:192,bufferSize:180000,targetSync:2800,
+    nStep:5,hiddenSizes:[256,256,128],
+    rewardConfig:{fruitReward:24,stepPenalty:0.006,timeoutPenalty:3},
+  },
+  ddqn_stage1:{
+    label:'DDQN Stage 1 – Warmup',
+    agent:'ddqn',
+    gamma:0.975,lr:0.00028,
+    epsStart:1.0,epsEnd:0.22,epsDecay:70000,
+    batchSize:96,bufferSize:50000,targetSync:1600,
+    nStep:2,hiddenSizes:[160,160,96],
+    priorityAlpha:0.5,priorityBeta:0.4,
+    rewardConfig:{fruitReward:13,stepPenalty:0.009,timeoutPenalty:4.8},
+  },
+  ddqn_stage2:{
+    label:'DDQN Stage 2 – Momentum',
+    agent:'ddqn',
+    gamma:0.982,lr:0.00022,
+    epsStart:0.95,epsEnd:0.17,epsDecay:90000,
+    batchSize:128,bufferSize:80000,targetSync:1900,
+    nStep:3,hiddenSizes:[192,192,128],
+    priorityAlpha:0.55,priorityBeta:0.48,
+    rewardConfig:{fruitReward:16,stepPenalty:0.0085,timeoutPenalty:4.2},
+  },
+  ddqn_stage3:{
+    label:'DDQN Stage 3 – Midgame Control',
+    agent:'ddqn',
+    gamma:0.988,lr:0.00018,
+    epsStart:0.9,epsEnd:0.14,epsDecay:105000,
+    batchSize:160,bufferSize:110000,targetSync:2200,
+    nStep:4,hiddenSizes:[224,224,128],
+    priorityAlpha:0.6,priorityBeta:0.55,
+    rewardConfig:{fruitReward:19,stepPenalty:0.0075,timeoutPenalty:3.8},
+  },
+  ddqn_stage4:{
+    label:'DDQN Stage 4 – Refinement',
+    agent:'ddqn',
+    gamma:0.992,lr:0.00012,
+    epsStart:0.85,epsEnd:0.1,epsDecay:125000,
+    batchSize:192,bufferSize:150000,targetSync:2600,
+    nStep:4,hiddenSizes:[256,256,160],
+    priorityAlpha:0.65,priorityBeta:0.6,
+    rewardConfig:{fruitReward:22,stepPenalty:0.0068,timeoutPenalty:3.4},
+  },
+  ddqn_stage5:{
+    label:'DDQN Stage 5 – Endgame',
+    agent:'ddqn',
+    gamma:0.995,lr:0.0001,
+    epsStart:0.8,epsEnd:0.08,epsDecay:150000,
+    batchSize:224,bufferSize:200000,targetSync:3000,
+    nStep:5,hiddenSizes:[256,256,192],
+    priorityAlpha:0.7,priorityBeta:0.65,
+    rewardConfig:{fruitReward:24,stepPenalty:0.006,timeoutPenalty:3},
+  },
+  rainbow_stage1:{
+    label:'Rainbow Stage 1 – Warmup',
+    agent:'rainbow',
+    gamma:0.975,lr:0.00025,
+    epsStart:1.0,epsEnd:0.18,epsDecay:80000,
+    batchSize:128,bufferSize:70000,targetSync:1700,
+    nStep:3,hiddenSizes:[192,192,128],
+    priorityAlpha:0.6,priorityBeta:0.45,learnRepeats:2,
+    rewardConfig:{fruitReward:15,stepPenalty:0.009,timeoutPenalty:4.5},
+  },
+  rainbow_stage2:{
+    label:'Rainbow Stage 2 – Expansion',
+    agent:'rainbow',
+    gamma:0.982,lr:0.0002,
+    epsStart:0.95,epsEnd:0.15,epsDecay:95000,
+    batchSize:160,bufferSize:100000,targetSync:2100,
+    nStep:4,hiddenSizes:[224,224,128],
+    priorityAlpha:0.65,priorityBeta:0.5,learnRepeats:2,
+    rewardConfig:{fruitReward:18,stepPenalty:0.008,timeoutPenalty:4},
+  },
+  rainbow_stage3:{
+    label:'Rainbow Stage 3 – Midgame Pressure',
+    agent:'rainbow',
+    gamma:0.988,lr:0.00016,
+    epsStart:0.9,epsEnd:0.12,epsDecay:115000,
+    batchSize:192,bufferSize:130000,targetSync:2500,
+    nStep:4,hiddenSizes:[256,256,128],
+    priorityAlpha:0.7,priorityBeta:0.55,learnRepeats:3,
+    rewardConfig:{fruitReward:20,stepPenalty:0.007,timeoutPenalty:3.6},
+  },
+  rainbow_stage4:{
+    label:'Rainbow Stage 4 – Advanced Planning',
+    agent:'rainbow',
+    gamma:0.992,lr:0.00012,
+    epsStart:0.85,epsEnd:0.1,epsDecay:135000,
+    batchSize:224,bufferSize:160000,targetSync:2900,
+    nStep:5,hiddenSizes:[288,288,160],
+    priorityAlpha:0.75,priorityBeta:0.6,learnRepeats:3,
+    rewardConfig:{fruitReward:22,stepPenalty:0.0065,timeoutPenalty:3.3},
+  },
+  rainbow_stage5:{
+    label:'Rainbow Stage 5 – Endgame',
+    agent:'rainbow',
+    gamma:0.995,lr:0.0001,
+    epsStart:0.8,epsEnd:0.08,epsDecay:160000,
+    batchSize:256,bufferSize:200000,targetSync:3300,
+    nStep:5,hiddenSizes:[320,320,192],
+    priorityAlpha:0.8,priorityBeta:0.65,learnRepeats:4,
+    rewardConfig:{fruitReward:24,stepPenalty:0.006,timeoutPenalty:3},
+  },
+  ppo_stage1:{
+    label:'PPO Stage 1 – Warmup',
+    agent:'ppo',
+    gamma:0.965,lr:0.0003,
+    lam:0.92,clipRatio:0.3,stepsPerEpoch:2048,
+    trainIters:3,minibatchSize:128,
+    entropy:0.01,valueCoef:0.45,
+    rewardConfig:{fruitReward:14,stepPenalty:0.01,timeoutPenalty:5},
+  },
+  ppo_stage2:{
+    label:'PPO Stage 2 – Stabilise',
+    agent:'ppo',
+    gamma:0.975,lr:0.00022,
+    lam:0.94,clipRatio:0.24,stepsPerEpoch:3072,
+    trainIters:4,minibatchSize:192,
+    entropy:0.008,valueCoef:0.5,
+    rewardConfig:{fruitReward:16,stepPenalty:0.009,timeoutPenalty:4.5},
+  },
+  ppo_stage3:{
+    label:'PPO Stage 3 – Midgame',
+    agent:'ppo',
+    gamma:0.985,lr:0.00018,
+    lam:0.96,clipRatio:0.2,stepsPerEpoch:4096,
+    trainIters:5,minibatchSize:256,
+    entropy:0.006,valueCoef:0.55,
+    rewardConfig:{fruitReward:18,stepPenalty:0.008,timeoutPenalty:4},
+  },
+  ppo_stage4:{
+    label:'PPO Stage 4 – Ramp Up',
+    agent:'ppo',
+    gamma:0.992,lr:0.00014,
+    lam:0.97,clipRatio:0.18,stepsPerEpoch:5120,
+    trainIters:6,minibatchSize:320,
+    entropy:0.005,valueCoef:0.6,
+    rewardConfig:{fruitReward:21,stepPenalty:0.007,timeoutPenalty:3.5},
+  },
+  ppo_stage5:{
+    label:'PPO Stage 5 – Endgame',
+    agent:'ppo',
+    gamma:0.995,lr:0.0001,
+    lam:0.98,clipRatio:0.15,stepsPerEpoch:6144,
+    trainIters:6,minibatchSize:384,
+    entropy:0.004,valueCoef:0.65,
+    rewardConfig:{fruitReward:24,stepPenalty:0.006,timeoutPenalty:3},
+  },
+  sac_stage1:{
+    label:'SAC Stage 1 – Warmup',
+    agent:'sac',
+    gamma:0.965,lr:0.0003,
+    lam:0.9,clipRatio:0.28,stepsPerEpoch:2048,
+    trainIters:3,minibatchSize:128,
+    entropy:0.02,valueCoef:0.35,
+    rewardConfig:{fruitReward:15,stepPenalty:0.0095,timeoutPenalty:4.8},
+  },
+  sac_stage2:{
+    label:'SAC Stage 2 – Exploration Balance',
+    agent:'sac',
+    gamma:0.975,lr:0.00022,
+    lam:0.93,clipRatio:0.22,stepsPerEpoch:3072,
+    trainIters:4,minibatchSize:192,
+    entropy:0.016,valueCoef:0.4,
+    rewardConfig:{fruitReward:17,stepPenalty:0.0085,timeoutPenalty:4.2},
+  },
+  sac_stage3:{
+    label:'SAC Stage 3 – Midgame Control',
+    agent:'sac',
+    gamma:0.985,lr:0.00016,
+    lam:0.95,clipRatio:0.18,stepsPerEpoch:4096,
+    trainIters:5,minibatchSize:256,
+    entropy:0.013,valueCoef:0.45,
+    rewardConfig:{fruitReward:19,stepPenalty:0.0075,timeoutPenalty:3.8},
+  },
+  sac_stage4:{
+    label:'SAC Stage 4 – Precision',
+    agent:'sac',
+    gamma:0.992,lr:0.00012,
+    lam:0.97,clipRatio:0.16,stepsPerEpoch:5120,
+    trainIters:6,minibatchSize:320,
+    entropy:0.01,valueCoef:0.5,
+    rewardConfig:{fruitReward:22,stepPenalty:0.0068,timeoutPenalty:3.4},
+  },
+  sac_stage5:{
+    label:'SAC Stage 5 – Endgame',
+    agent:'sac',
+    gamma:0.995,lr:0.0001,
+    lam:0.98,clipRatio:0.14,stepsPerEpoch:6144,
+    trainIters:6,minibatchSize:384,
+    entropy:0.008,valueCoef:0.55,
+    rewardConfig:{fruitReward:24,stepPenalty:0.006,timeoutPenalty:3},
+  },
+};
+
+const STAGE_PRESET_PLACEHOLDER='Select stage preset';
+
+function resolveAgentKey(rawAgent,fallback='dueling'){
+  if(rawAgent&&AGENT_PRESETS[rawAgent]) return rawAgent;
+  if(rawAgent&&STAGE_AGENT_ALIASES[rawAgent]) return STAGE_AGENT_ALIASES[rawAgent];
+  return fallback;
+}
+
+function getStageAgentKey(preset,fallback='dueling'){
+  if(!preset||typeof preset!=='object') return fallback;
+  return resolveAgentKey(preset.agent,fallback);
+}
+
 const ui={
   trainState:document.getElementById('trainState'),
   algoBadge:document.getElementById('algoBadge'),
@@ -3333,6 +3593,11 @@ const ui={
     ppo:document.querySelector('[data-config="ppo"]'),
   },
 };
+
+let presetSelectEl=null;
+let stageSelectEl=null;
+let currentStagePresetKey='';
+let stagePresetField=null;
 
 let agent=null;
 let stateDim=env?.getState()?.length||0;
@@ -4602,11 +4867,19 @@ function updateAdvancedVisibility(){
   });
 }
 function instantiateAgent(key,opts={}){
+  const {useCurrentUI=false,overrideDefaults=null}=opts;
   currentAlgoKey=AGENT_PRESETS[key]?key:'dueling';
   ui.algoSelect.value=currentAlgoKey;
   const preset=AGENT_PRESETS[currentAlgoKey];
-  if(!opts.useCurrentUI){
-    applyPresetToUI(preset.defaults);
+  const appliedDefaults={...preset.defaults};
+  if(overrideDefaults){
+    if(Array.isArray(overrideDefaults.layers)) appliedDefaults.layers=overrideDefaults.layers.slice();
+    if(overrideDefaults.learnRepeats!==undefined) appliedDefaults.learnRepeats=overrideDefaults.learnRepeats;
+    if(overrideDefaults.dueling!==undefined) appliedDefaults.dueling=overrideDefaults.dueling;
+    if(overrideDefaults.double!==undefined) appliedDefaults.double=overrideDefaults.double;
+  }
+  if(!useCurrentUI){
+    applyPresetToUI(appliedDefaults);
   }
   agent=preset.create(stateDim,actionDim,{
     gamma:+ui.gamma.value,
@@ -4626,17 +4899,22 @@ function instantiateAgent(key,opts={}){
     lambda:+ui.ppoLambda.value,
     batch:+ui.ppoBatch.value,
     epochs:+ui.ppoEpochs.value,
-    learnRepeats:preset.defaults.learnRepeats,
-    layers:preset.defaults.layers,
-    dueling:preset.defaults.dueling,
-    double:preset.defaults.double,
+    learnRepeats:appliedDefaults.learnRepeats,
+    layers:appliedDefaults.layers,
+    dueling:appliedDefaults.dueling,
+    double:appliedDefaults.double,
   });
-  agent.learnRepeats=preset.defaults.learnRepeats??agent.learnRepeats??1;
+  agent.learnRepeats=(appliedDefaults.learnRepeats??preset.defaults.learnRepeats)??agent.learnRepeats??1;
   targetSyncSteps=agent.kind==='dqn'? (+ui.targetSync.value||2000):Infinity;
   updateAdvancedVisibility();
   ui.algoBadge.textContent=preset.badge||preset.label;
   ui.algoDescription.textContent=preset.description;
+  if(typeof presetSelectEl!=='undefined'&&presetSelectEl&&presetSelectEl.value!==currentAlgoKey){
+    presetSelectEl.value=currentAlgoKey;
+  }
   updateBadgeMetrics();
+  currentStagePresetKey='';
+  refreshStagePresetOptions(currentAlgoKey,{preserveSelection:false});
   resetTrainingStats();
   if(agent.kind!=='dqn' && trainingMode==='auto'){
     setTrainingMode('manual');
@@ -4680,6 +4958,118 @@ function applyPresetToUI(config){
   if(config.batch!==undefined) ui.ppoBatch.value=config.batch;
   if(config.epochs!==undefined) ui.ppoEpochs.value=config.epochs;
   updateReadouts();
+}
+function applyPreset(preset,options={}){
+  if(!preset) return;
+  const {preserveProgress=false}=options;
+  const agentKey=getStageAgentKey(preset,currentAlgoKey);
+  const overrides={};
+  if(Array.isArray(preset.hiddenSizes)) overrides.layers=preset.hiddenSizes.slice();
+  if(preset.learnRepeats!==undefined) overrides.learnRepeats=preset.learnRepeats;
+  if(preset.dueling!==undefined) overrides.dueling=preset.dueling;
+  if(preset.double!==undefined) overrides.double=preset.double;
+  const {
+    label,
+    agent:_stageAgent,
+    rewardConfig,
+    hiddenSizes:_hiddenSizes,
+    learnRepeats:_learnRepeats,
+    lam,
+    clipRatio,
+    stepsPerEpoch:_stepsPerEpoch,
+    trainIters,
+    minibatchSize,
+    batchSize,
+    ...rest
+  }=preset;
+  const config={...rest};
+  if(batchSize!==undefined) config.batch=batchSize;
+  if(minibatchSize!==undefined) config.batch=minibatchSize;
+  if(lam!==undefined) config.lambda=lam;
+  if(clipRatio!==undefined) config.clip=clipRatio;
+  if(trainIters!==undefined) config.epochs=trainIters;
+  // remove properties not handled by UI
+  delete config.agent;
+  delete config.label;
+  delete config.rewardConfig;
+  delete config.hiddenSizes;
+  delete config.learnRepeats;
+  delete config.lam;
+  delete config.clipRatio;
+  delete config.stepsPerEpoch;
+  delete config.trainIters;
+  delete config.minibatchSize;
+  delete config.batchSize;
+  applyPresetToUI(config);
+  if(rewardConfig) applyRewardConfigToUI({...rewardConfig});
+  applyRewardsToEnv();
+  const overrideArg=Object.keys(overrides).length?overrides:null;
+  const targetPreset=AGENT_PRESETS[agentKey];
+  currentAlgoKey=agentKey;
+  ui.algoSelect.value=agentKey;
+  if(presetSelectEl) presetSelectEl.value=agentKey;
+  const hasProgress=episode>0||totalSteps>0;
+  const canPreserve=preserveProgress&&agent&&targetPreset&&currentAlgoKey===agentKey&&hasProgress;
+  if(canPreserve){
+    if(overrideArg&&overrideArg.learnRepeats!==undefined) agent.learnRepeats=overrideArg.learnRepeats;
+    ui.algoBadge.textContent=label||targetPreset.badge||targetPreset.label;
+    applyConfigToAgent();
+    updateReadouts();
+    return;
+  }
+  instantiateAgent(agentKey,{useCurrentUI:true,overrideDefaults:overrideArg});
+  if(label) ui.algoBadge.textContent=label;
+  applyConfigToAgent();
+  updateReadouts();
+}
+
+function refreshStagePresetOptions(agentKey,{preserveSelection=true}={}){
+  if(!stageSelectEl) return;
+  const fallback=agentKey&&AGENT_PRESETS[agentKey]?agentKey:'dueling';
+  const targetAgent=resolveAgentKey(agentKey,fallback);
+  const previousValue=preserveSelection?(stageSelectEl.value||currentStagePresetKey):'';
+  stageSelectEl.innerHTML='';
+  const placeholder=document.createElement('option');
+  placeholder.value='';
+  placeholder.textContent=STAGE_PRESET_PLACEHOLDER;
+  stageSelectEl.appendChild(placeholder);
+  const entries=[];
+  for(const [key,preset] of Object.entries(STAGE_PRESETS)){
+    if(resolveAgentKey(preset.agent,targetAgent)===targetAgent){
+      entries.push({key,label:preset.label});
+    }
+  }
+  const hasEntries=entries.length>0;
+  if(stagePresetField){
+    stagePresetField.classList.toggle('hidden',!hasEntries);
+  }
+  if(!hasEntries){
+    placeholder.textContent='No stage presets available';
+    stageSelectEl.disabled=true;
+    currentStagePresetKey='';
+    stageSelectEl.value='';
+    return;
+  }
+  stageSelectEl.disabled=false;
+  const availableKeys=new Set();
+  entries.forEach(({key,label})=>{
+    const option=document.createElement('option');
+    option.value=key;
+    option.textContent=label;
+    stageSelectEl.appendChild(option);
+    availableKeys.add(key);
+  });
+  if(preserveSelection&&previousValue&&availableKeys.has(previousValue)){
+    stageSelectEl.value=previousValue;
+    currentStagePresetKey=previousValue;
+    return;
+  }
+  if(currentStagePresetKey&&availableKeys.has(currentStagePresetKey)){
+    stageSelectEl.value=currentStagePresetKey;
+    return;
+  }
+  currentStagePresetKey='';
+  stageSelectEl.value='';
 }
 function resetTrainingStats(){
   episode=0;
@@ -5426,6 +5816,50 @@ async function loadTrainingFromFile(file){
 }
 
 /* ---------------- Init ---------------- */
+const presetSelect=document.getElementById('presetSelect');
+if(presetSelect){
+  presetSelectEl=presetSelect;
+  for(const [key,preset] of Object.entries(AGENT_PRESETS)){
+    const option=document.createElement('option');
+    option.value=key;
+    option.textContent=preset.label;
+    if(key===currentAlgoKey) option.selected=true;
+    presetSelect.appendChild(option);
+  }
+  presetSelect.addEventListener('change',e=>{
+    const key=e.target.value;
+    if(AGENT_PRESETS[key]){
+      instantiateAgent(key);
+    }
+  });
+}
+
+const stageSelect=document.getElementById('stagePresetSelect');
+if(stageSelect){
+  stageSelectEl=stageSelect;
+  stagePresetField=stageSelect.closest('.field');
+  refreshStagePresetOptions(currentAlgoKey);
+  stageSelect.addEventListener('change',e=>{
+    const presetKey=e.target.value;
+    if(!presetKey){
+      currentStagePresetKey='';
+      if(AGENT_PRESETS[currentAlgoKey]){
+        const basePreset=AGENT_PRESETS[currentAlgoKey];
+        ui.algoBadge.textContent=basePreset.badge||basePreset.label;
+      }
+      refreshStagePresetOptions(currentAlgoKey);
+      return;
+    }
+    const preset=STAGE_PRESETS[presetKey];
+    if(preset){
+      applyPreset(preset,{preserveProgress:true});
+      currentStagePresetKey=presetKey;
+      refreshStagePresetOptions(currentAlgoKey);
+      stageSelect.value=presetKey;
+    }
+  });
+}
+
 aiTuner=createAITuner({
   getVecEnv:()=>vecEnv,
   fetchTelemetry:({interval})=>buildAITelemetrySnapshot(interval),


### PR DESCRIPTION
## Summary
- hide the agent preset picker and present a dedicated stage preset dropdown that filters options by the chosen algorithm
- add helpers that resolve stage agent aliases, refresh the stage list, and hide the field when no presets apply
- reuse the current agent when applying a stage preset mid-training so progress and rewards carry forward

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dadfd875d08324ae2e2fe820868e64