### PR TITLE
Remove auto pause support from AI tuner

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -46,14 +46,13 @@ Output must always be strict JSON in this format:
     "snakeLength": <number>,
     "fruitEaten": <number>
   },
-  "pause": <false>,
   "analysisText": "<short explanation (1–3 sentences)>"
-}  
+}
 
 Rules:
-- Always include ALL fields, even if unchanged.  
-- Never output extra commentary or markdown. JSON only.  
-- If "pause": true, analysisText must explain why.  `;
+- Always include ALL fields, even if unchanged.
+- Never output extra commentary or markdown. JSON only.
+- If you recommend halting training, explain it within analysisText.  `;
 
 
 const DEFAULT_ALLOWED_ORIGINS = [

--- a/index.html
+++ b/index.html
@@ -4289,24 +4289,6 @@ async function handleGroqResponse(responseJson){
       return;
     }
 
-    if(parsed.pause===true){
-      console.warn("⏸️ AI beslutade att pausa träningen:", parsed.analysisText);
-      if(typeof pauseTraining==='function'){
-        pauseTraining();
-      }else if(typeof stopTraining==='function'){
-        stopTraining();
-      }
-      return;
-    }
-
-    if(parsed.pause===false){
-      if(typeof resumeTraining==='function'){
-        resumeTraining();
-      }else if(!training && typeof startTraining==='function'){
-        startTraining();
-      }
-    }
-
     const allowAutoAdjustment=aiAutoTuneEnabled&&aiAutoAdjustEnabled;
     let adjustmentsDeferred=false;
 


### PR DESCRIPTION
## Summary
- remove the pause directive from the Groq system prompt
- drop client-side handling of pause/resume instructions from AI responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc8b6a02483248feb20ffb9025a6a