### PR TITLE
Add toggleable path overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,26 @@ canvas#board{
   border:1px solid rgba(128,138,206,0.2);
   box-shadow:0 16px 34px rgba(6,10,30,0.38);
 }
+.path-visual-overlay{
+  display:flex;
+  justify-content:flex-end;
+  align-items:center;
+  margin-top:8px;
+  color:var(--muted);
+  font-size:12px;
+}
+.path-visual-overlay label{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  font-weight:600;
+  color:#e7ebff;
+}
+.path-visual-overlay input[type="checkbox"]{
+  width:18px;
+  height:18px;
+  accent-color:var(--accent-a);
+}
 .controls.tertiary{
   width:100%;
   justify-content:space-between;
@@ -995,6 +1015,9 @@ footer{
         <span class="mono" id="gridLabel">20×20</span>
       </div>
     </div>
+    <section class="path-visual-overlay" aria-label="Path Visualisation">
+      <label><input type="checkbox" id="showPathOverlay"> Show BFS / Hamilton Overlay</label>
+    </section>
   </section>
 
   <section class="card control-card">
@@ -1618,6 +1641,7 @@ footer{
 <script type="module" src="hf-tuner.js"></script>
 <script type="module">
 import {createAITuner} from './hf-tuner.js';
+import {bfsDistance, bfsPath, generateHamiltonCycle} from './src/path_helpers.js';
 
 const DEBUG_LOG=false;
 
@@ -3368,6 +3392,8 @@ let envCount=1;
 let vecEnv=new VecSnakeEnv(envCount,{cols:COLS,rows:ROWS,rewardConfig});
 let renderIndex=0;
 let env=vecEnv.getEnv(renderIndex);
+let hamiltonCycle=generateHamiltonCycle(COLS);
+window.overlayVisible=Boolean(window.overlayVisible);
 
 function snapshotEnv(environment){
   return {
@@ -3498,6 +3524,7 @@ function drawFrame(from,to,t){
     return {x:sx+(seg.x-sx)*t,y:sy+(seg.y-sy)*t};
   });
   drawSnakeSegments(segments);
+  drawOverlay(to);
 }
 function drawGrid(){
   bctx.save();
@@ -3564,6 +3591,42 @@ function drawSnakeSegments(segments){
     drawRoundedRect(x,y,size,size,radius);
   });
   bctx.restore();
+}
+function drawOverlay(state){
+  if(!window.overlayVisible) return;
+  const ctx=bctx;
+  const cell=CELL;
+  ctx.save();
+  if(hamiltonCycle.length>1){
+    ctx.strokeStyle='rgba(0,255,0,0.2)';
+    ctx.lineWidth=1;
+    ctx.beginPath();
+    for(let i=0;i<hamiltonCycle.length;i++){
+      const current=hamiltonCycle[i];
+      const next=hamiltonCycle[(i+1)%hamiltonCycle.length];
+      ctx.moveTo((current.x+0.5)*cell,(current.y+0.5)*cell);
+      ctx.lineTo((next.x+0.5)*cell,(next.y+0.5)*cell);
+    }
+    ctx.stroke();
+  }
+  const snake=state?.snake||[];
+  const fruit=state?.fruit;
+  if(fruit&&snake.length){
+    const path=bfsPath(COLS,snake,fruit);
+    if(path.length>1){
+      ctx.strokeStyle='rgba(0,128,255,0.6)';
+      ctx.lineWidth=2;
+      ctx.beginPath();
+      for(let i=0;i<path.length-1;i++){
+        const a=path[i];
+        const b=path[i+1];
+        ctx.moveTo((a.x+0.5)*cell,(a.y+0.5)*cell);
+        ctx.lineTo((b.x+0.5)*cell,(b.y+0.5)*cell);
+      }
+      ctx.stroke();
+    }
+  }
+  ctx.restore();
 }
 function drawRoundedRect(x,y,w,h,r){
   const radius=Math.max(2,Math.min(r,Math.min(w,h)/2));
@@ -3956,6 +4019,7 @@ const ui={
   playbackButtons:Array.from(document.querySelectorAll('#playbackGroup .pill')),
   gridSize:document.getElementById('gridSize'),
   gridLabel:document.getElementById('gridLabel'),
+  showPathOverlay:document.getElementById('showPathOverlay'),
   btnToggleLiveView:document.getElementById('btnToggleLiveView'),
   btnTrain:document.getElementById('btnTrain'),
   btnPause:document.getElementById('btnPause'),
@@ -4820,6 +4884,15 @@ function bindUI(){
       resetEnvironment(desiredSize,true);
     }
   });
+  if(ui.showPathOverlay){
+    window.overlayVisible=ui.showPathOverlay.checked;
+    ui.showPathOverlay.addEventListener('change',()=>{
+      window.overlayVisible=ui.showPathOverlay.checked;
+      if(lastDrawnState){
+        drawFrame(lastDrawnState,lastDrawnState,1);
+      }
+    });
+  }
   ui.btnReset.addEventListener('click',()=>resetEnvironment(+ui.gridSize.value,true));
   ui.btnTrain.addEventListener('click',startTraining);
   ui.btnPause.addEventListener('click',stopTraining);
@@ -4982,6 +5055,7 @@ function reconfigureEnvironment({count=envCount,size=COLS,force=false}={}){
   COLS=desiredSize;
   ROWS=desiredSize;
   CELL=board.width/COLS;
+  hamiltonCycle=generateHamiltonCycle(COLS);
   stateDim=env?.getState()?.length||stateDim;
   seedContexts(true);
   agent?.setEnvCount?.(envCount);

--- a/src/path_helpers.js
+++ b/src/path_helpers.js
@@ -1,0 +1,98 @@
+export function bfsPath(gridSize, snake = [], fruit) {
+  const size = Number.isFinite(gridSize) ? gridSize | 0 : 0;
+  if (size <= 0 || !fruit || typeof fruit.x !== 'number' || typeof fruit.y !== 'number') {
+    return [];
+  }
+  if (!Array.isArray(snake) || snake.length === 0) {
+    return [];
+  }
+  const head = snake[0];
+  if (typeof head?.x !== 'number' || typeof head?.y !== 'number') {
+    return [];
+  }
+  const dirs = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ];
+  const key = (x, y) => `${x},${y}`;
+  const blocked = new Set();
+  for (const segment of snake) {
+    if (segment && Number.isFinite(segment.x) && Number.isFinite(segment.y)) {
+      blocked.add(key(segment.x, segment.y));
+    }
+  }
+  const visited = new Set();
+  const prev = new Map();
+  const queue = [{ x: head.x, y: head.y }];
+  let qIndex = 0;
+  visited.add(key(head.x, head.y));
+
+  while (qIndex < queue.length) {
+    const current = queue[qIndex++];
+    const currentKey = key(current.x, current.y);
+    if (current.x === fruit.x && current.y === fruit.y) {
+      const path = [{ x: current.x, y: current.y }];
+      let cursorKey = currentKey;
+      while (prev.has(cursorKey)) {
+        const parent = prev.get(cursorKey);
+        cursorKey = key(parent.x, parent.y);
+        path.unshift({ x: parent.x, y: parent.y });
+      }
+      return path;
+    }
+    for (const [dx, dy] of dirs) {
+      const nx = current.x + dx;
+      const ny = current.y + dy;
+      if (nx < 0 || ny < 0 || nx >= size || ny >= size) continue;
+      const nextKey = key(nx, ny);
+      if (visited.has(nextKey)) continue;
+      if (blocked.has(nextKey) && !(nx === fruit.x && ny === fruit.y)) continue;
+      visited.add(nextKey);
+      prev.set(nextKey, { x: current.x, y: current.y });
+      queue.push({ x: nx, y: ny });
+    }
+  }
+  return [];
+}
+
+export function bfsDistance(gridSize, snake = [], fruit) {
+  const path = bfsPath(gridSize, snake, fruit);
+  return path.length ? path.length - 1 : -1;
+}
+
+export function generateHamiltonCycle(size) {
+  const n = Number.isFinite(size) ? size | 0 : 0;
+  if (n < 2 || n % 2 !== 0) {
+    return [];
+  }
+  if (n === 2) {
+    return [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 1 },
+      { x: 0, y: 1 },
+    ];
+  }
+  const cycle = [];
+  for (let x = 0; x < n; x++) {
+    cycle.push({ x, y: 0 });
+  }
+  for (let y = 1; y < n; y++) {
+    cycle.push({ x: n - 1, y });
+  }
+  for (let x = n - 2; x >= 0; x--) {
+    cycle.push({ x, y: n - 1 });
+  }
+  for (let y = n - 2; y >= 2; y--) {
+    cycle.push({ x: 0, y });
+  }
+  const inner = generateHamiltonCycle(n - 2);
+  for (let i = inner.length - 1; i >= 0; i--) {
+    const point = inner[i];
+    cycle.push({ x: point.x + 1, y: point.y + 1 });
+  }
+  cycle.push({ x: 0, y: 1 });
+  return cycle;
+}


### PR DESCRIPTION
## Summary
- add a checkbox in the game controls to toggle the BFS/Hamilton visual overlay
- draw Hamilton cycles and BFS fruit paths on the canvas when the overlay is enabled
- extract reusable BFS path and Hamilton cycle helpers for the renderer

## Testing
- node -e "const {generateHamiltonCycle}=require('./src/path_helpers.js');const n=6;const cycle=generateHamiltonCycle(n);const ok=cycle.length===n*n&&cycle.every((p,i)=>{const next=cycle[(i+1)%cycle.length];return Math.abs(p.x-next.x)+Math.abs(p.y-next.y)===1;});console.log('n',n,'len',cycle.length,'ok',ok);"

------
https://chatgpt.com/codex/tasks/task_e_68e110e15dac8324b8ebd0db836fac12