### PR TITLE
Add BFS and Hamilton reward controls to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1300,6 +1300,26 @@ footer{
           </label>
         </div>
       </div>
+      <section class="path-helper-controls" aria-label="Path Helper Rewards">
+        <h4>BFS / Hamilton Rewards</h4>
+
+        <label>
+          BFS Weight:
+          <input type="range" id="bfsSlider" min="0" max="0.5" step="0.01" value="0.20">
+          <span id="bfsVal">0.20</span>
+        </label><br>
+
+        <label>
+          Hamilton Weight:
+          <input type="range" id="hamSlider" min="0" max="0.2" step="0.01" value="0.05">
+          <span id="hamVal">0.05</span>
+        </label><br>
+
+        <label>
+          <input type="checkbox" id="usePathHelpers" checked>
+          Enable BFS / Hamilton
+        </label>
+      </section>
     </details>
 
     <details id="advancedPanel" open>
@@ -1661,6 +1681,9 @@ const REWARD_DEFAULTS={
   compactWeight:0,
   trapPenalty:0.5,
   spaceGainBonus:0.05,
+  bfsWeight:0.2,
+  hamiltonWeight:0.05,
+  usePathHelpers:true,
 };
 const REWARD_COMPONENTS=[
   {key:'fruitReward',label:'Fruit bonus',sign:'positive'},
@@ -1714,6 +1737,9 @@ const REWARD_INPUT_IDS={
   fruitReward:'rewardFruit',
   growthBonus:'rewardGrowth',
   compactWeight:'rewardCompact',
+  bfsWeight:'bfsSlider',
+  hamiltonWeight:'hamSlider',
+  usePathHelpers:'usePathHelpers',
 };
 const RECENT_EPISODES_MAX=32;
 const ROLLUP_WINDOW=1000;
@@ -4115,6 +4141,11 @@ const ui={
   rewardGrowthReadout:document.getElementById('rewardGrowthReadout'),
   rewardCompact:document.getElementById('rewardCompact'),
   rewardCompactReadout:document.getElementById('rewardCompactReadout'),
+  bfsSlider:document.getElementById('bfsSlider'),
+  bfsVal:document.getElementById('bfsVal'),
+  hamSlider:document.getElementById('hamSlider'),
+  hamVal:document.getElementById('hamVal'),
+  usePathHelpers:document.getElementById('usePathHelpers'),
   kEpisodes:document.getElementById('kEpisodes'),
   kAvgRw:document.getElementById('kAvgRw'),
   kBest:document.getElementById('kBest'),
@@ -4275,6 +4306,8 @@ const REWARD_DECIMALS={
   trapPenalty:3,
   spaceGainBonus:3,
   timeoutPenalty:1,
+  bfsWeight:2,
+  hamiltonWeight:2,
 };
 function describeRewardDetail(adj){
   if(!adj||typeof adj!=='object') return 'Reward';
@@ -4979,6 +5012,35 @@ function bindUI(){
   const rewardIds=['rewardStep','rewardTurn','rewardApproach','rewardRetreat','rewardLoop','rewardRevisit','rewardWall','rewardSelf','rewardTimeout','rewardTrap','rewardSpace','rewardDeadEnd','rewardFruit','rewardGrowth','rewardCompact'];
   const updateRewards=()=>{ updateRewardReadouts(); applyRewardsToEnv(); };
   rewardIds.forEach(id=>ui[id]?.addEventListener('input',updateRewards));
+  const bfsSlider=document.getElementById('bfsSlider');
+  const hamSlider=document.getElementById('hamSlider');
+  const usePathHelpers=document.getElementById('usePathHelpers');
+
+  bfsSlider?.addEventListener('input',()=>{
+    const val=parseFloat(bfsSlider.value);
+    ui.bfsVal.textContent=val.toFixed(2);
+    if(agent){
+      agent.rewardConfig={...(agent.rewardConfig||{}),bfsWeight:val};
+    }
+    updateRewards();
+  });
+
+  hamSlider?.addEventListener('input',()=>{
+    const val=parseFloat(hamSlider.value);
+    ui.hamVal.textContent=val.toFixed(2);
+    if(agent){
+      agent.rewardConfig={...(agent.rewardConfig||{}),hamiltonWeight:val};
+    }
+    updateRewards();
+  });
+
+  usePathHelpers?.addEventListener('change',()=>{
+    const enabled=usePathHelpers.checked;
+    if(agent){
+      agent.rewardConfig={...(agent.rewardConfig||{}),usePathHelpers:enabled};
+    }
+    applyRewardsToEnv();
+  });
   ui.tabTraining.addEventListener('click',()=>setActiveTab('training'));
   ui.tabGuide.addEventListener('click',()=>setActiveTab('guide'));
   updateReadouts();
@@ -5264,6 +5326,8 @@ function updateRewardReadouts(){
   ui.rewardFruitReadout.textContent=(+ui.rewardFruit.value).toFixed(1);
   ui.rewardGrowthReadout.textContent=(+ui.rewardGrowth.value).toFixed(1);
   ui.rewardCompactReadout.textContent=(+ui.rewardCompact.value).toFixed(3);
+  ui.bfsVal.textContent=(+ui.bfsSlider.value).toFixed(2);
+  ui.hamVal.textContent=(+ui.hamSlider.value).toFixed(2);
 }
 function getRewardConfigFromUI(){
   return {
@@ -5282,6 +5346,9 @@ function getRewardConfigFromUI(){
     fruitReward:+ui.rewardFruit.value,
     growthBonus:+ui.rewardGrowth.value,
     compactWeight:+ui.rewardCompact.value,
+    bfsWeight:+ui.bfsSlider.value,
+    hamiltonWeight:+ui.hamSlider.value,
+    usePathHelpers:ui.usePathHelpers.checked,
   };
 }
 function applyRewardsToEnv(){
@@ -5289,6 +5356,10 @@ function applyRewardsToEnv(){
   vecEnv?.setRewardConfig(rewardConfig);
   env=vecEnv?.getEnv(renderIndex)||env;
   autoPilot?.setRewardConfig?.({...rewardConfig});
+  if(agent){
+    agent.rewardConfig={...(agent.rewardConfig||{}),...rewardConfig};
+    agent.setRewardConfig?.({...rewardConfig});
+  }
 }
 function applyRewardConfigToUI(config={}){
   if(config.stepPenalty!==undefined) ui.rewardStep.value=config.stepPenalty;
@@ -5306,6 +5377,9 @@ function applyRewardConfigToUI(config={}){
   if(config.fruitReward!==undefined) ui.rewardFruit.value=config.fruitReward;
   if(config.growthBonus!==undefined) ui.rewardGrowth.value=config.growthBonus;
   if(config.compactWeight!==undefined) ui.rewardCompact.value=config.compactWeight;
+  if(config.bfsWeight!==undefined) ui.bfsSlider.value=config.bfsWeight;
+  if(config.hamiltonWeight!==undefined) ui.hamSlider.value=config.hamiltonWeight;
+  if(config.usePathHelpers!==undefined) ui.usePathHelpers.checked=!!config.usePathHelpers;
   updateRewardReadouts();
   applyRewardsToEnv();
 }
@@ -6295,6 +6369,7 @@ function instantiateAgent(key,opts={}){
   }
   updateAutoPpoVisibility();
   autoPilot?.setAgent?.(agent);
+  agent.rewardConfig={...(agent.rewardConfig||{}),...rewardConfig};
   updateControlAvailability();
   updateReadouts();
 }


### PR DESCRIPTION
## Summary
- add BFS and Hamilton reward sliders plus toggle to the reward tuning panel
- propagate slider values into the reward configuration defaults and live agent/env updates
- synchronize UI readouts and agent rewardConfig values for the new helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e115e632e88324aaea5b4f9302c5cc