### PR TITLE
Add periodic greedy evaluation logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,6 +465,12 @@ select{
   font-size:20px;
   color:#f6f7ff;
 }
+.kpi .item span.gap-positive{
+  color:#34d399;
+}
+.kpi .item span.gap-negative{
+  color:var(--danger);
+}
 .progress-chart{
   background:linear-gradient(160deg,rgba(30,36,78,0.9) 0%,rgba(17,20,44,0.92) 100%);
   border:1px solid var(--stroke);
@@ -1071,6 +1077,7 @@ footer{
       <div class="item"><b>Fruit / ep</b><span id="kFruitRate">0.0</span></div>
       <div class="item"><b>Greedy Fruit (avg)</b><span id="greedyFruitStat">—</span></div>
       <div class="item"><b>Greedy Reward (avg)</b><span id="greedyRewardStat">—</span></div>
+      <div class="item"><b>Gap (Fruit − Greedy)</b><span id="greedyGapStat">—</span></div>
     </div>
 
     <p class="hint" id="algoDescription">Prioritized replay, n-step returns, and dueling heads make DQN stable and sample efficient.</p>
@@ -1742,11 +1749,18 @@ const REWARD_INPUT_IDS={
 };
 const RECENT_EPISODES_MAX=32;
 const ROLLUP_WINDOW=1000;
+const telemetry={
+  greedyFruit:[],
+  greedyReward:[],
+  greedyGap:[],
+  fruitPerEpAvg:0,
+  greedyGapLatest:undefined,
+};
 let rewardConfig={...REWARD_DEFAULTS};
 let hyperParams={};
 const LOOP_PATTERNS=new Set(['1,2,1,2','2,1,2,1']);
-const GREEDY_INTERVAL=1000;
-const GREEDY_EPISODES=10;
+const GREEDY_EVAL_INTERVAL=2000;
+const GREEDY_EVAL_RUNS=10;
 
 /* ---------------- Serialization helpers ---------------- */
 const DTYPE_ARRAYS={float32:Float32Array,int32:Int32Array,bool:Uint8Array};
@@ -4151,6 +4165,7 @@ const ui={
   kFruitRate:document.getElementById('kFruitRate'),
   greedyFruitStat:document.getElementById('greedyFruitStat'),
   greedyRewardStat:document.getElementById('greedyRewardStat'),
+  greedyGapStat:document.getElementById('greedyGapStat'),
   rewardTelemetryBody:document.getElementById('rewardTelemetryBody'),
   rewardTelemetrySummary:document.getElementById('rewardTelemetrySummary'),
   rewardTelemetryPanel:document.getElementById('rewardTelemetryPanel'),
@@ -4698,6 +4713,17 @@ function buildAITelemetrySnapshot(intervalOverride){
     },
     recentEpisodes,
     latestEpisode,
+    greedy:{
+      lastFruit:telemetry.greedyFruit.length?telemetry.greedyFruit[telemetry.greedyFruit.length-1]:null,
+      lastReward:telemetry.greedyReward.length?telemetry.greedyReward[telemetry.greedyReward.length-1]:null,
+      lastGap:telemetry.greedyGapLatest??(telemetry.greedyGap.length?telemetry.greedyGap[telemetry.greedyGap.length-1]:null),
+      history:{
+        episodes:greedyEpisodeHist.slice(-recentWindow),
+        fruit:telemetry.greedyFruit.slice(-recentWindow),
+        reward:telemetry.greedyReward.slice(-recentWindow),
+        gap:telemetry.greedyGap.slice(-recentWindow),
+      },
+    },
   };
 }
 
@@ -6029,6 +6055,7 @@ function updateAutoPpoVisibility(){
 
 if(typeof window!=='undefined'){
   window.AutoPPOController=AutoPPOController;
+  window.telemetry=telemetry;
 }
 
 class BrowserAutoPilot{
@@ -6528,6 +6555,11 @@ function resetTrainingStats(){
   greedyFruitHist.length=0;
   greedyRewardHist.length=0;
   greedyEpisodeHist.length=0;
+  telemetry.greedyFruit.length=0;
+  telemetry.greedyReward.length=0;
+  telemetry.greedyGap.length=0;
+  telemetry.fruitPerEpAvg=0;
+  telemetry.greedyGapLatest=undefined;
   window.autoPpo?.reset();
   rewardTelemetry.reset();
   updateStatsUI();
@@ -6552,9 +6584,12 @@ function resetTrainingStats(){
 }
 function updateStatsUI(){
   ui.kEpisodes.textContent=episode;
-  ui.kAvgRw.textContent=avg(rwHist,100).toFixed(2);
+  const avgReward100=avg(rwHist,100);
+  const fruitAvg100=avg(fruitHist,100);
+  telemetry.fruitPerEpAvg=fruitAvg100;
+  ui.kAvgRw.textContent=avgReward100.toFixed(2);
   ui.kBest.textContent=bestLen;
-  ui.kFruitRate.textContent=avg(fruitHist,100).toFixed(2);
+  ui.kFruitRate.textContent=fruitAvg100.toFixed(2);
   if(ui.greedyFruitStat){
     if(greedyFruitHist.length){
       ui.greedyFruitStat.textContent=greedyFruitHist[greedyFruitHist.length-1].toFixed(2);
@@ -6567,6 +6602,23 @@ function updateStatsUI(){
       ui.greedyRewardStat.textContent=greedyRewardHist[greedyRewardHist.length-1].toFixed(2);
     }else{
       ui.greedyRewardStat.textContent='—';
+    }
+  }
+  if(ui.greedyGapStat){
+    ui.greedyGapStat.classList.remove('gap-positive','gap-negative');
+    if(greedyFruitHist.length){
+      const latestGreedy=greedyFruitHist[greedyFruitHist.length-1];
+      const gapValue=fruitAvg100-latestGreedy;
+      ui.greedyGapStat.textContent=gapValue.toFixed(2);
+      telemetry.greedyGapLatest=gapValue;
+      if(gapValue>30){
+        ui.greedyGapStat.classList.add('gap-negative');
+      }else if(gapValue<20){
+        ui.greedyGapStat.classList.add('gap-positive');
+      }
+    }else{
+      ui.greedyGapStat.textContent='—';
+      telemetry.greedyGapLatest=undefined;
     }
   }
 }
@@ -6705,12 +6757,6 @@ function recordProgressPoint(){
   if(progressPoints.length>PROGRESS_POINTS_MAX) progressPoints.shift();
   updateProgressChart();
 }
-function logGreedyMetrics(fruit,reward,episodeNumber){
-  console.log(`[GREEDY EVAL] ep=${episodeNumber} | avgFruit=${fruit.toFixed(2)} | avgReward=${reward.toFixed(2)}`);
-  greedyFruitHist.push(fruit);
-  greedyRewardHist.push(reward);
-  greedyEpisodeHist.push(episodeNumber);
-}
 function updateRewardTelemetryUI(){
   if(!ui.rewardTelemetryBody) return;
   const {rows,total}=rewardTelemetry.summary();
@@ -6765,7 +6811,7 @@ async function finalizeContextEpisode(ctx,envIndex){
     if(lossHist.length>1000) lossHist.shift();
   }
   episode++;
-  if(episode>0 && episode%GREEDY_INTERVAL===0){
+  if(episode>0 && episode%GREEDY_EVAL_INTERVAL===0){
     pendingGreedyEvalEpisode=episode;
   }
   rwHist.push(ctx.totalReward);
@@ -6911,11 +6957,11 @@ async function applyAutoAdjustments(adjustments){
   updateReadouts();
   logAutoAdjustments(adjustments);
 }
-async function runGreedyEvaluation(currentEpisode){
-  if(!agent||!vecEnv) return;
-  const savedEpsilon=typeof agent.epsilon==='number'?agent.epsilon:null;
-  if(savedEpsilon!==null) agent.epsilon=0;
-  const evalCount=Math.min(Math.max(1,envCount|0),GREEDY_EPISODES);
+async function evalGreedyEpisodes(agentRef,runCount=GREEDY_EVAL_RUNS,referenceEpisode=episode){
+  if(!agentRef||!vecEnv) return null;
+  const prevEps=typeof agentRef.epsilon==='number'?agentRef.epsilon:null;
+  if(prevEps!==null) agentRef.epsilon=0;
+  const evalCount=Math.min(Math.max(1,envCount|0),Math.max(1,runCount|0));
   const evalEnv=new VecSnakeEnv(evalCount,{cols:COLS,rows:ROWS,rewardConfig});
   let states=evalEnv.resetAll().map(state=>Float32Array.from(state));
   const episodeRewards=new Array(evalCount).fill(0);
@@ -6923,12 +6969,11 @@ async function runGreedyEvaluation(currentEpisode){
   let completed=0;
   let totalReward=0;
   let totalFruit=0;
-  let finished=false;
-  while(!finished){
+  while(completed<runCount){
     const actions=states.map(state=>{
       const input=state instanceof Float32Array?state:Float32Array.from(state);
-      if(typeof agent.greedyAction==='function') return agent.greedyAction(input);
-      return agent.act(input);
+      if(typeof agentRef.greedyAction==='function') return agentRef.greedyAction(input);
+      return agentRef.act(input);
     });
     const {nextStates,rewards,dones,ateFruit}=evalEnv.step(actions);
     for(let i=0;i<evalCount;i+=1){
@@ -6938,27 +6983,40 @@ async function runGreedyEvaluation(currentEpisode){
       if(dones[i]){
         totalReward+=episodeRewards[i];
         totalFruit+=episodeFruits[i];
-        completed+=1;
         episodeRewards[i]=0;
         episodeFruits[i]=0;
-        if(completed>=GREEDY_EPISODES){
-          finished=true;
-          break;
-        }
+        completed+=1;
+        if(completed>=runCount) break;
         states[i]=Float32Array.from(evalEnv.resetEnv(i));
       }
     }
-    if(!finished) await tf.nextFrame();
+    if(completed<runCount) await tf.nextFrame();
   }
-  const greedyFruitAvg=completed?totalFruit/completed:0;
-  const greedyRewardAvg=completed?totalReward/completed:0;
-  logGreedyMetrics(greedyFruitAvg,greedyRewardAvg,currentEpisode);
+  const gFruit=runCount?totalFruit/runCount:0;
+  const gReward=runCount?totalReward/runCount:0;
+  const fruitPerEp=Number.isFinite(telemetry.fruitPerEpAvg)?telemetry.fruitPerEpAvg:0;
+  const gap=fruitPerEp-gFruit;
+  telemetry.greedyFruit.push(gFruit);
+  telemetry.greedyReward.push(gReward);
+  telemetry.greedyGap.push(gap);
+  telemetry.greedyGapLatest=gap;
+  if(telemetry.greedyFruit.length>6000) telemetry.greedyFruit.shift();
+  if(telemetry.greedyReward.length>6000) telemetry.greedyReward.shift();
+  if(telemetry.greedyGap.length>6000) telemetry.greedyGap.shift();
+  greedyFruitHist.push(gFruit);
+  greedyRewardHist.push(gReward);
+  greedyEpisodeHist.push(referenceEpisode??episode);
+  if(greedyFruitHist.length>6000) greedyFruitHist.shift();
+  if(greedyRewardHist.length>6000) greedyRewardHist.shift();
+  if(greedyEpisodeHist.length>6000) greedyEpisodeHist.shift();
+  console.log(`🍏 Greedy Fruit(avg): ${gFruit.toFixed(2)}  |  Gap: ${gap.toFixed(2)}`);
+  if(prevEps!==null){
+    agentRef.epsilon=prevEps;
+    ui.epsReadout.textContent=prevEps.toFixed(2);
+  }
   updateStatsUI();
   updateProgressChart();
-  if(savedEpsilon!==null){
-    agent.epsilon=savedEpsilon;
-    ui.epsReadout.textContent=savedEpsilon.toFixed(2);
-  }
+  return {fruit:gFruit,reward:gReward,gap};
 }
 async function performVectorStep(mode){
   ensureContextPool();
@@ -7039,7 +7097,7 @@ async function performVectorStep(mode){
     const evalTarget=pendingGreedyEvalEpisode;
     pendingGreedyEvalEpisode=0;
     try{
-      await runGreedyEvaluation(evalTarget);
+      await evalGreedyEpisodes(agent,GREEDY_EVAL_RUNS,evalTarget);
       lastGreedyEvalEpisode=evalTarget;
     }catch(err){
       console.error('Greedy evaluation failed',err);


### PR DESCRIPTION
## Summary
- add telemetry buffers and UI stat for tracking greedy performance gap
- run a zero-epsilon VecSnake evaluation every 2000 episodes and log fruit/reward averages
- expose greedy metrics to charts/telemetry and colour the gap readout based on thresholds

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e133c426e883248f668eff5942602a