### PR TITLE
Add tail-follow fallback for unreachable fruit paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -7718,6 +7718,71 @@ window.addEventListener('load',()=>{
     return new Float32Array();
   }
 
+  function normalizeDirection(dir) {
+    const dx = Number.isFinite(dir?.x) ? Math.sign(dir.x) : 1;
+    const dy = Number.isFinite(dir?.y) ? Math.sign(dir.y) : 0;
+    if (dx === 0 && dy === 0) return { x: 1, y: 0 };
+    if (![ -1, 0, 1 ].includes(dx) || ![ -1, 0, 1 ].includes(dy)) {
+      return { x: 1, y: 0 };
+    }
+    return { x: dx, y: dy };
+  }
+
+  function boardSize(env) {
+    const cols = Number.isFinite(env?.cols) ? env.cols | 0 : 0;
+    const rows = Number.isFinite(env?.rows) ? env.rows | 0 : 0;
+    if (cols && rows) return Math.max(cols, rows);
+    return cols || rows || 0;
+  }
+
+  function nextStepAction(dir, head, path) {
+    if (!Array.isArray(path) || path.length < 2) return null;
+    if (!head || !Number.isFinite(head.x) || !Number.isFinite(head.y)) return null;
+    const next = path[1];
+    if (!next || !Number.isFinite(next.x) || !Number.isFinite(next.y)) return null;
+    const dx = next.x - head.x;
+    const dy = next.y - head.y;
+    const forward = dir;
+    const left = { x: -forward.y, y: forward.x };
+    const right = { x: forward.y, y: -forward.x };
+    if (dx === forward.x && dy === forward.y) return 0;
+    if (dx === left.x && dy === left.y) return 1;
+    if (dx === right.x && dy === right.y) return 2;
+    return null;
+  }
+
+  function planTailFollowAction(env, { debug = false } = {}) {
+    const snake = Array.isArray(env?.snake) ? env.snake : null;
+    if (!snake || snake.length === 0) return null;
+    const size = boardSize(env);
+    if (!size) return null;
+    const head = snake[0];
+    if (!head) return null;
+    const dir = normalizeDirection(env?.dir);
+
+    const fruit = env?.fruit;
+    const hasFruit = fruit && Number.isFinite(fruit.x) && Number.isFinite(fruit.y);
+    if (hasFruit) {
+      const pathToFruit = bfsPath(size, snake, fruit);
+      const fruitAction = nextStepAction(dir, head, pathToFruit);
+      if (fruitAction !== null) {
+        return { type: 'fruit', action: fruitAction, path: pathToFruit };
+      }
+    }
+
+    const tail = snake[snake.length - 1];
+    if (!tail || !Number.isFinite(tail.x) || !Number.isFinite(tail.y)) return null;
+    const pathToTail = bfsPath(size, snake, tail);
+    const tailAction = nextStepAction(dir, head, pathToTail);
+    if (tailAction !== null) {
+      if (debug && typeof console !== 'undefined' && typeof console.log === 'function') {
+        console.log('🐍 Following tail for safety');
+      }
+      return { type: 'tail', action: tailAction, path: pathToTail };
+    }
+    return null;
+  }
+
   function selectAction(agent, state, train) {
     if (!agent) return 0;
     try {
@@ -7773,6 +7838,8 @@ window.addEventListener('load',()=>{
     if (!env) throw new Error('[snake-env] Environment is required');
     if (!agent) throw new Error('[snake-env] Agent is required');
     const { train = true, render = false } = options;
+    const tailFollowFallback = options.tailFollowFallback ?? !train;
+    const debugTailFallback = options.debugTailFallback ?? false;
     const cols = env.cols ?? 20;
     const rows = env.rows ?? 20;
     const maxSteps = Number.isFinite(options.maxSteps)
@@ -7803,7 +7870,13 @@ window.addEventListener('load',()=>{
         }
       }
 
-      const action = selectAction(agent, state, train);
+      let action = selectAction(agent, state, train);
+      if (tailFollowFallback) {
+        const fallback = planTailFollowAction(env, { debug: debugTailFallback });
+        if (fallback?.type === 'tail' && fallback.action !== null) {
+          action = fallback.action;
+        }
+      }
       const result = env.step(action) ?? {};
       const nextState = toFloatState(result.state);
       const reward = Number(result.reward ?? 0);

--- a/snake-env.js
+++ b/snake-env.js
@@ -1,3 +1,5 @@
+import { bfsPath } from './src/path_helpers.js';
+
 const LOOP_FACTOR = 6;
 
 function toFloatState(state) {
@@ -6,6 +8,71 @@ function toFloatState(state) {
   if (Array.isArray(state)) return Float32Array.from(state);
   if (state && typeof state.length === 'number') return Float32Array.from(state);
   return new Float32Array();
+}
+
+function normalizeDirection(dir) {
+  const dx = Number.isFinite(dir?.x) ? Math.sign(dir.x) : 1;
+  const dy = Number.isFinite(dir?.y) ? Math.sign(dir.y) : 0;
+  if (dx === 0 && dy === 0) return { x: 1, y: 0 };
+  if (![ -1, 0, 1 ].includes(dx) || ![ -1, 0, 1 ].includes(dy)) {
+    return { x: 1, y: 0 };
+  }
+  return { x: dx, y: dy };
+}
+
+function boardSize(env) {
+  const cols = Number.isFinite(env?.cols) ? env.cols | 0 : 0;
+  const rows = Number.isFinite(env?.rows) ? env.rows | 0 : 0;
+  if (cols && rows) return Math.max(cols, rows);
+  return cols || rows || 0;
+}
+
+function nextStepAction(dir, head, path) {
+  if (!Array.isArray(path) || path.length < 2) return null;
+  if (!head || !Number.isFinite(head.x) || !Number.isFinite(head.y)) return null;
+  const next = path[1];
+  if (!next || !Number.isFinite(next.x) || !Number.isFinite(next.y)) return null;
+  const dx = next.x - head.x;
+  const dy = next.y - head.y;
+  const forward = dir;
+  const left = { x: -forward.y, y: forward.x };
+  const right = { x: forward.y, y: -forward.x };
+  if (dx === forward.x && dy === forward.y) return 0;
+  if (dx === left.x && dy === left.y) return 1;
+  if (dx === right.x && dy === right.y) return 2;
+  return null;
+}
+
+function planTailFollowAction(env, { debug = false } = {}) {
+  const snake = Array.isArray(env?.snake) ? env.snake : null;
+  if (!snake || snake.length === 0) return null;
+  const size = boardSize(env);
+  if (!size) return null;
+  const head = snake[0];
+  if (!head) return null;
+  const dir = normalizeDirection(env?.dir);
+
+  const fruit = env?.fruit;
+  const hasFruit = fruit && Number.isFinite(fruit.x) && Number.isFinite(fruit.y);
+  if (hasFruit) {
+    const pathToFruit = bfsPath(size, snake, fruit);
+    const fruitAction = nextStepAction(dir, head, pathToFruit);
+    if (fruitAction !== null) {
+      return { type: 'fruit', action: fruitAction, path: pathToFruit };
+    }
+  }
+
+  const tail = snake[snake.length - 1];
+  if (!tail || !Number.isFinite(tail.x) || !Number.isFinite(tail.y)) return null;
+  const pathToTail = bfsPath(size, snake, tail);
+  const tailAction = nextStepAction(dir, head, pathToTail);
+  if (tailAction !== null) {
+    if (debug && typeof console !== 'undefined' && typeof console.log === 'function') {
+      console.log('🐍 Following tail for safety');
+    }
+    return { type: 'tail', action: tailAction, path: pathToTail };
+  }
+  return null;
 }
 
 function selectAction(agent, state, train) {
@@ -63,6 +130,8 @@ export async function runEpisode(env, agent, options = {}) {
   if (!env) throw new Error('[snake-env] Environment is required');
   if (!agent) throw new Error('[snake-env] Agent is required');
   const { train = true, render = false } = options;
+  const tailFollowFallback = options.tailFollowFallback ?? !train;
+  const debugTailFallback = options.debugTailFallback ?? false;
   const cols = env.cols ?? 20;
   const rows = env.rows ?? 20;
   const maxSteps = Number.isFinite(options.maxSteps)
@@ -93,7 +162,13 @@ export async function runEpisode(env, agent, options = {}) {
       }
     }
 
-    const action = selectAction(agent, state, train);
+    let action = selectAction(agent, state, train);
+    if (tailFollowFallback) {
+      const fallback = planTailFollowAction(env, { debug: debugTailFallback });
+      if (fallback?.type === 'tail' && fallback.action !== null) {
+        action = fallback.action;
+      }
+    }
     const result = env.step(action) ?? {};
     const nextState = toFloatState(result.state);
     const reward = Number(result.reward ?? 0);


### PR DESCRIPTION
## Summary
- import the BFS helper in the shared snake environment and add utilities to derive an action from a path
- apply a tail-follow fallback inside `runEpisode` when fruit paths are unreachable, with optional debug logging
- mirror the new helpers in the inline browser environment so watch mode benefits from the same safety fallback

## Testing
- `node --input-type=module -e "import('./snake-env.js').then(m=>console.log('runEpisode',typeof m.runEpisode)).catch(err=>{console.error(err);process.exit(1);});"`


------
https://chatgpt.com/codex/tasks/task_e_68e15e4f027483248a955b20eb4f7125