### PR TITLE
Embed Final Watch evaluator in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -7916,183 +7916,129 @@ window.addEventListener('load',()=>{
 
   window.runEpisode = runEpisode;
   window.snakeEnv = { runEpisode };
+  if (typeof window !== 'undefined') {
+    window.SnakeEnv = window.SnakeEnv ?? SnakeEnv;
+    window.SnakeEnvironment = window.SnakeEnvironment ?? SnakeEnv;
+  }
 </script>
 
-<!-- Final Watch integrated inline -->
+<!-- === FINAL WATCH TEST BUTTON === -->
+<div id="finalWatchUI" style="text-align:center;margin:1em 0;">
+  <button id="runFinalWatchBtn"
+          style="padding:0.6em 1.2em;font-size:1em;border-radius:8px;
+                 background:#0a84ff;color:#fff;border:none;cursor:pointer;">
+    ▶️ Run Final Watch Test
+  </button>
+  <div id="finalWatchSummary"
+       style="margin-top:0.5em;font-family:monospace;"></div>
+</div>
+
+<!-- === FINAL WATCH – robust ε=0 evaluator === -->
 <script type="module">
-  // === FINAL WATCH HELPER ===
+async function runFinalWatch({
+  makeEnv, makeAgent, agent,
+  episodes=100, maxSteps=null,
+  seed=1337, fromCheckpoint=true,
+  checkpointPath=null, baseEnv=null, onProgress=null,
+}={}) {
+  const evalAgent = agent ?? (typeof makeAgent==='function'?makeAgent():null);
+  if(!evalAgent) throw new Error('FinalWatch: No agent provided.');
 
-  function requireRunEpisode() {
-    if (typeof window.runEpisode !== 'function') {
-      throw new Error('Snake environment is not available.');
+  if(fromCheckpoint){
+    try{
+      if(checkpointPath && evalAgent.loadCheckpoint)
+        await evalAgent.loadCheckpoint(checkpointPath);
+      else if(evalAgent.tryAutoLoad) await evalAgent.tryAutoLoad();
+      else if(evalAgent.loadLatest) await evalAgent.loadLatest();
+    }catch(e){console.warn('Checkpoint load failed',e);}
+  }
+
+  if(evalAgent.setEvalMode) evalAgent.setEvalMode(true);
+  if(evalAgent.freezeTraining) evalAgent.freezeTraining(true);
+
+  const policy=(s)=>{
+    if(evalAgent.predictQ){
+      const q=evalAgent.predictQ(s);let bi=0,bv=-1e9;
+      for(let i=0;i<q.length;i++) if(q[i]>bv){bv=q[i];bi=i;}
+      return bi;
     }
-    return window.runEpisode;
-  }
+    return evalAgent.act?evalAgent.act(s,{epsilon:0}):0;
+  };
 
-  async function runFinalWatch(agent, env, episodes = 100) {
-    console.log('🟢 Starting Final Watch Mode...');
-    // Save current state to restore after test
-    const savedState = {
-      epsilon: agent.epsilon,
-      epsilonStart: agent.epsilonStart,
-      epsilonEnd: agent.epsilonEnd,
-      training: agent.training,
-      autoActive: window.autoActive ?? false,
-      aiAutoTuneEnabled: window.aiAutoTuneEnabled ?? false,
-    };
-
-    // Disable all training activity
-    agent.training = false;
-    agent.epsilon = 0;
-    window.autoActive = false;
-    window.aiAutoTuneEnabled = false;
-
-    const results = {
-      fruit: [],
-      reward: [],
-      steps: [],
-      wallCrashes: 0,
-      selfCrashes: 0,
-      loopCrashes: 0,
-    };
-
-    const runEpisode = requireRunEpisode();
-    for (let i = 0; i < episodes; i++) {
-      const { totalReward, fruitEaten, steps, crashType } = await runEpisode(env, agent, {
-        train: false,
-        render: true,
-      });
-
-      results.fruit.push(fruitEaten);
-      results.reward.push(totalReward);
-      results.steps.push(steps);
-
-      if (crashType === 'wall') results.wallCrashes++;
-      else if (crashType === 'self') results.selfCrashes++;
-      else if (crashType === 'loop') results.loopCrashes++;
-
-      document.dispatchEvent(
-        new CustomEvent('watchUpdate', { detail: { i, fruitEaten, totalReward } })
-      );
+  const cloneEnv=()=>{
+    const e=makeEnv?makeEnv():null;
+    if(!e) throw new Error('makeEnv() required');
+    if(baseEnv){
+      if(baseEnv.rewardConfig) e.rewardConfig=JSON.parse(JSON.stringify(baseEnv.rewardConfig));
+      if(baseEnv.gridSize) e.gridSize=baseEnv.gridSize;
+      if(baseEnv.maxSteps) e.maxSteps=baseEnv.maxSteps;
     }
+    if(e.seed) e.seed(seed);
+    return e;
+  };
 
-    const summary = {
-      episodes,
-      avgFruit: avg(results.fruit),
-      avgReward: avg(results.reward),
-      avgSteps: avg(results.steps),
-      wallRate: results.wallCrashes / episodes,
-      selfRate: results.selfCrashes / episodes,
-      loopRate: results.loopCrashes / episodes,
-      timestamp: new Date().toLocaleString(),
-    };
+  let fruits=0,rewardSum=0,stepsSum=0,wall=0,self=0,loop=0;
+  for(let ep=0;ep<episodes;ep++){
+    const env=cloneEnv();let f=0,r=0,s=0,cr=false,ct=null;
+    const hook=(o,e,fn)=>{if(o?.on)o.on(e,fn);else if(o?.addEventListener)o.addEventListener(e,fn);};
+    hook(env,'fruit',()=>f++); hook(env,'crash',t=>{cr=true;ct=t;});
 
-    console.log('🏁 Final Watch Summary:', summary);
-    renderFinalStats(summary, savedState);
-    exportResults(summary);
-    renderMiniSummary(summary);
-    return summary;
-  }
+    let st=env.reset?.()??env.init?.()??env.getState?.();
+    if(!st){const d=(evalAgent.stateSize??evalAgent.sDim??128)|0;st=new Array(d).fill(0);}
+    const lim=(maxSteps??env.maxSteps??1000)|0;
 
-  function avg(a) {
-    return a.reduce((x, y) => x + y, 0) / a.length;
-  }
-
-  // --- Floating overlay after test ---
-  function renderFinalStats(s, savedState) {
-    const old = document.getElementById('finalWatchStats');
-    if (old) old.remove();
-
-    const div = document.createElement('div');
-    div.id = 'finalWatchStats';
-    div.className =
-      'final-watch-stats absolute top-4 right-4 bg-black/70 text-white p-3 rounded-xl shadow-lg text-sm font-mono z-50';
-    div.innerHTML = `
-      <h3 class="font-bold text-base mb-2">🏁 Final Watch Stats</h3>
-      <p>Episodes: ${s.episodes}</p>
-      <p>Avg Fruit: ${s.avgFruit.toFixed(2)}</p>
-      <p>Avg Reward: ${s.avgReward.toFixed(1)}</p>
-      <p>Avg Steps: ${s.avgSteps.toFixed(0)}</p>
-      <p>Wall crash rate: ${(s.wallRate * 100).toFixed(1)}%</p>
-      <p>Self crash rate: ${(s.selfRate * 100).toFixed(1)}%</p>
-      <p>Loop crash rate: ${(s.loopRate * 100).toFixed(1)}%</p>
-      <div class="flex gap-2 mt-2">
-        <button id="exportFinalWatch" class="btn accent">💾 Export JSON</button>
-        <button id="resumeTraining" class="btn success">▶️ Resume Training</button>
-      </div>
-    `;
-    document.body.appendChild(div);
-
-    document
-      .getElementById('exportFinalWatch')
-      ?.addEventListener('click', () => exportResults(s));
-
-    document
-      .getElementById('resumeTraining')
-      ?.addEventListener('click', () => restoreTraining(savedState));
-  }
-
-  // --- Add small summary box inside existing stats panel ---
-  function renderMiniSummary(s) {
-    let panel = document.getElementById('miniFinalSummary');
-    if (!panel) {
-      const statsPanel = document.querySelector('.stats-panel, .ai-stats, .training-stats');
-      if (!statsPanel) {
-        console.warn('⚠️ No stats panel found for mini summary');
-        return;
-      }
-      panel = document.createElement('div');
-      panel.id = 'miniFinalSummary';
-      panel.className = 'mini-final-summary border-t mt-2 pt-1 text-xs font-mono';
-      statsPanel.appendChild(panel);
+    for(let t=0;t<lim;t++){
+      const a=policy(st);
+      const tr=env.step(a);
+      const rw=Number(tr?.reward??0); r+=rw; s++;
+      if(rw>0) f++;
+      st=tr?.nextState??env.getState?.()??st;
+      if(tr?.done){cr|=!!tr.info?.crash;ct=ct||tr.info?.crash;break;}
     }
-
-    panel.innerHTML = `
-      <div class="flex flex-col gap-0.5">
-        <strong class="text-accent">🏁 Last Final Test (${s.timestamp})</strong>
-        <span>Fruit: ${s.avgFruit.toFixed(2)}</span>
-        <span>Reward: ${s.avgReward.toFixed(1)}</span>
-        <span>Steps: ${s.avgSteps.toFixed(0)}</span>
-        <span>Wall: ${(s.wallRate * 100).toFixed(1)}% | Self: ${(s.selfRate * 100).toFixed(1)}% | Loop: ${(s.loopRate * 100).toFixed(1)}%</span>
-      </div>
-    `;
-  }
-
-  // --- JSON export helper ---
-  function exportResults(data) {
-    const blob = new Blob([JSON.stringify(data, null, 2)], {
-      type: 'application/json',
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'final-watch-results.json';
-    a.click();
-    URL.revokeObjectURL(url);
-    console.log('💾 Exported final-watch-results.json');
-  }
-
-  // --- Restore all parameters and continue training ---
-  function restoreTraining(state) {
-    const agent = window.agent;
-    if (!agent) return;
-    agent.epsilon = state.epsilon;
-    agent.epsilonStart = state.epsilonStart;
-    agent.epsilonEnd = state.epsilonEnd;
-    agent.training = state.training;
-    window.autoActive = state.autoActive;
-    window.aiAutoTuneEnabled = state.aiAutoTuneEnabled;
-
-    const uiDiv = document.getElementById('finalWatchStats');
-    if (uiDiv) uiDiv.remove();
-
-    console.log('🔁 Restored previous training state, resuming...');
-    if (typeof window.startTraining === 'function') {
-      window.startTraining();
+    if(!f&&env.fruitEaten) f=env.fruitEaten;
+    if(!cr&&env.lastCrashType){cr=true;ct=env.lastCrashType;}
+    if(cr){
+      const t=String(ct||'').toLowerCase();
+      if(t.includes('wall')) wall++; else if(t.match(/self|tail|body/)) self++;
+      else if(t.includes('loop')) loop++; else if(r<-50) wall++; else self++;
     }
+    fruits+=f; rewardSum+=r; stepsSum+=s;
   }
 
-  window.runFinalWatch = runFinalWatch;
+  const res={
+    episodes,
+    avgFruit:+(fruits/episodes).toFixed(4),
+    avgReward:+(rewardSum/episodes).toFixed(4),
+    avgSteps:+(stepsSum/episodes).toFixed(4),
+    wallRate:+(wall/episodes).toFixed(4),
+    selfRate:+(self/episodes).toFixed(4),
+    loopRate:+(loop/episodes).toFixed(4),
+    timestamp:new Date().toISOString().replace('T',' ').slice(0,19)
+  };
+
+  document.getElementById('finalWatchSummary').textContent =
+    `🍎 ${res.avgFruit}  💰 ${res.avgReward}  🪜 ${res.avgSteps}  🧱 ${res.wallRate*100}% wall  🐍 ${res.selfRate*100}% self`;
+
+  const blob=new Blob([JSON.stringify(res,null,2)],{type:'application/json'});
+  const a=document.createElement('a'); a.href=URL.createObjectURL(blob);
+  a.download='final-watch-results.json'; a.click(); URL.revokeObjectURL(a.href);
+  console.log('Final Watch Result:',res);
+  return res;
+}
+
+// Bind test button
+const btn=document.getElementById('runFinalWatchBtn');
+if(btn){
+  btn.addEventListener('click',()=>runFinalWatch({
+    makeEnv:window.createEnv??(()=>new SnakeEnvironment()),
+    makeAgent:window.createAgent??null,
+    agent:window.agent??null,
+    baseEnv:window.trainingEnv??null,
+    episodes:20,  // shorter test run
+    seed:20251004,
+    fromCheckpoint:true
+  }));
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose the existing SnakeEnv class on window so the Final Watch helper can instantiate environments
- replace the old Final Watch helper with an inline ε=0 evaluator and summary UI block inside index.html
- add a prominent "Run Final Watch Test" button that downloads results for offline GitHub Pages use

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e161408884832482104ec3370a58a7