### PR TITLE
Expose tail follow helper to window

### DIFF
--- a/index.html
+++ b/index.html
@@ -8094,6 +8094,11 @@ window.addEventListener('load',()=>{
     return null;
   }
 
+  if (typeof window !== 'undefined') {
+    window.planTailFollowAction = planTailFollowAction;
+    window.snakeEnv = { ...(window.snakeEnv ?? {}), planTailFollowAction };
+  }
+
   function selectAction(agent, state, train) {
     if (!agent) return 0;
     try {
@@ -8226,7 +8231,7 @@ window.addEventListener('load',()=>{
   }
 
   window.runEpisode = runEpisode;
-  window.snakeEnv = { runEpisode };
+  window.snakeEnv = { ...(window.snakeEnv ?? {}), runEpisode };
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- expose the inline planTailFollowAction helper on window so other scripts can use it
- keep snakeEnv exports merged when attaching runEpisode so both helpers remain available

## Testing
- not run (UI only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2c8c82b248324b6a36a5e1fc6ef7e