### PR TITLE
Ensure curriculum toggle resets start length

### DIFF
--- a/index.html
+++ b/index.html
@@ -4713,9 +4713,25 @@ const curriculumState={
     }
   },
   setManualEnabled(value){
-    this.manualEnabled=!!value;
+    const nextEnabled=!!value;
+    this.manualEnabled=nextEnabled;
     this.autoCursor=0;
-    if(this.manualEnabled) this.lastStartLength=this.manualLength;
+    if(this.manualEnabled){
+      this.lastStartLength=this.manualLength;
+    }else{
+      const baseline=this.getBaselineStartLength(0);
+      this.lastStartLength=baseline;
+      if(vecEnv&&typeof vecEnv.getEnv==='function'){
+        for(let i=0;i<vecEnv.envCount;i+=1){
+          const envRef=vecEnv.getEnv(i);
+          if(!envRef) continue;
+          const defaultLen=Number.isFinite(envRef?.defaultStartLength)
+            ?Math.max(1,Math.round(envRef.defaultStartLength))
+            :baseline;
+          envRef.baseStartLength=defaultLen;
+        }
+      }
+    }
     this.save();
   },
   setManualLength(value){


### PR DESCRIPTION
## Summary
- reset each environment's base start length to its default whenever the late-game curriculum is disabled
- restore the curriculum state's last start length to the baseline when turning the toggle off so manual runs start from three apples again

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e41ac90eb083248d21d67f3042914a