### PR TITLE
Fix vec env import path and add IDLE instructions

### DIFF
--- a/snakepython/README.md
+++ b/snakepython/README.md
@@ -1,0 +1,115 @@
+# Snake-ML Python-port
+
+Det här projektet är en Python-port av Marcus Peterssons Snake-ML med stöd för Gymnasium, Stable-Baselines3, PyTorch och ONNX-export. Repositoriet återskapar hela logiken från webbläsarversionen och gör det möjligt att träna ormen i realtid via `pygame`, köra flera miljöer parallellt och exportera modeller till Snake-ML:s "Watch"-läge.
+
+## Förutsättningar
+
+* Python 3.10+ (3.11 rekommenderas)
+* `pip` och `virtualenv`/`venv`
+* Systempaket för att kunna kompilera PyTorch och använda `pygame` (exempelvis `sudo apt-get install python3-dev python3-venv build-essential libSDL2-dev` på Debian/Ubuntu)
+
+## Snabbstart
+
+```bash
+cd snakepython
+./install.sh        # skapar virtuell miljö .venv/ och installerar dependencies
+source .venv/bin/activate
+python train_dqn.py # startar DQN-träning med realtidsrendering
+```
+
+> Tips: Lägg till flaggan `--tensorboard` till träningsskripten för att aktivera TensorBoard-loggning under `./tb_snake/`.
+
+### Köra skripten via IDLE (Windows)
+
+1. Öppna **IDLE (Python)** och välj `File → Open...`, peka på exempelvis `train_dqn.py` inuti mappen `snakepython`.
+2. Kör först installationssteget en gång genom att öppna `install.sh` i en vanlig kommandotolk och köra `bash install.sh` (om du saknar Bash kan du istället skapa miljön manuellt med `py -m venv .venv` följt av `.\.venv\Scripts\activate` och `py -m pip install -r requirements.txt`).
+3. Tillbaka i IDLE: välj `Run → Run Module` (F5). När fönstret med ormen dyker upp är träningen igång. Om du vill dölja renderingen kan du sätta flaggan `--headless` högst upp i `if __name__ == "__main__":`-blocket eller köra skriptet från kommandoraden.
+
+> Notera: IDLE använder den Python-installation du startade programmet med. Se till att samma installation har tillgång till det virtuella envet `.venv` (via `Select Interpreter` eller genom att aktivera `.venv` innan du startar IDLE).
+
+## Manuella installationssteg
+
+Föredrar du att göra allt manuellt kan du följa dessa steg:
+
+```bash
+cd snakepython
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Träna modeller
+
+| Script | Beskrivning | Standardparametrar |
+| ------ | ----------- | ------------------ |
+| `train_dqn.py` | Tränar en DQN-agent med åtta parallella miljöer. Renderar miljö 0 i realtid. | 500 000 steg, `CnnPolicy`, `tensorboard_log="./tb_snake/"` när flaggan används. |
+| `train_ppo.py` | Tränar en PPO-agent med samma miljö och motsvarande loggning. | `learning_rate=3e-4`, `gamma=0.975`, `n_steps=2048`, m.fl. |
+
+Samtliga skript tar emot följande vanliga flaggor:
+
+* `--timesteps <int>` – antal träningssteg (standard 500_000).
+* `--grid-size <int>` – rutnätsstorlek (10–20 rekommenderas).
+* `--tensorboard` – aktivera TensorBoard-loggar.
+* `--seed <int>` – sätt slumpfrö.
+
+### Multi-run launcher
+
+För att starta flera oberoende träningssessioner (t.ex. på olika seeds) kan du använda `utils/run_multi_train.py`:
+
+```bash
+python utils/run_multi_train.py --runs 4 --algo dqn --timesteps 200000
+```
+
+Detta skapar fyra processer som var och en sparar modeller i `models/<algo>_snake_runX.zip` och loggar till `tb_snake/runX/`.
+
+## Utvärdera en modell
+
+När träningen är klar kan du spela upp agenten i tio episoder:
+
+```bash
+python evaluate.py --model models/dqn_snake_<timestamp>.zip
+```
+
+Fönstret visar ormen live och terminalen skriver `Episode N | Reward: X | Fruits: Y | Steps: Z`.
+
+## Export till ONNX och JSON
+
+```bash
+python export_model.py --model models/dqn_snake_<timestamp>.zip
+```
+
+Skriptet skapar:
+
+* `export/snake_agent.onnx` – ONNX-modellen (inputformat `[1, 3, grid_size, grid_size]`).
+* `export/snake_agent.json` – meta- och viktinformation som kan laddas i Snake-ML:s webbläsargränssnitt.
+
+## Integration med Snake-ML-webben
+
+Lägg till följande i webbkoden:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
+<button id="loadPythonModelBtn">🧠 Load Trained Model (Python)</button>
+```
+
+När knappen klickas:
+
+```javascript
+const session = await ort.InferenceSession.create('export/snake_agent.onnx');
+const input = new ort.Tensor('float32', gridData, [1, 3, gridSize, gridSize]);
+const output = await session.run({ input });
+const action = output.action.data[0];
+```
+
+Växla mellan "Browser Agent" och "Python Model (ONNX)" i Watch-läget och spara valet i `localStorage`.
+
+## Vanliga frågor
+
+**Renderingen hackar när jag kör flera miljöer.** Endast miljö `index 0` renderas i realtid för att undvika att pygame-fönster krockar. Övriga miljöer körs i bakgrunden.
+
+**Kan jag köra utan rendering?** Ja, sätt miljön i silent mode via flaggan `--headless` på träningsskripten. Miljön kommer då inte att öppna något fönster.
+
+**Hur återupptar jag träning från en sparad modell?** Båda träningsskripten accepterar flaggan `--load <model_path>` för att återuppta träning.
+
+Lycka till med träningen!

--- a/snakepython/evaluate.py
+++ b/snakepython/evaluate.py
@@ -1,0 +1,53 @@
+"""Evaluate a trained Snake agent and stream the game via pygame."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from stable_baselines3 import DQN, PPO
+
+from snake_env import SnakeEnv
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate a trained Snake model")
+    parser.add_argument("model", type=Path, help="Path to the saved SB3 .zip model")
+    parser.add_argument("--algo", choices=["dqn", "ppo"], default="dqn")
+    parser.add_argument("--episodes", type=int, default=10)
+    parser.add_argument("--grid-size", type=int, default=15)
+    return parser.parse_args()
+
+
+def load_model(path: Path, algo: str):
+    if algo == "dqn":
+        return DQN.load(path)
+    if algo == "ppo":
+        return PPO.load(path)
+    raise ValueError(f"Unsupported algorithm: {algo}")
+
+
+def main() -> None:
+    args = parse_args()
+    model = load_model(args.model, args.algo)
+
+    env = SnakeEnv(grid_size=args.grid_size, render_mode="human", show_window=True)
+
+    for episode in range(1, args.episodes + 1):
+        obs, info = env.reset()
+        done = False
+        total_reward = 0.0
+        fruits = 0
+        steps = 0
+        while not done:
+            action, _ = model.predict(obs, deterministic=True)
+            obs, reward, terminated, truncated, info = env.step(action)
+            total_reward += float(reward)
+            fruits = info.get("fruits", fruits)
+            steps += 1
+            done = terminated or truncated
+        print(f"Episode {episode} | Reward: {total_reward:.2f} | Fruits: {fruits} | Steps: {steps}")
+    env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/snakepython/export_model.py
+++ b/snakepython/export_model.py
@@ -1,0 +1,146 @@
+"""Export Stable-Baselines3 Snake agents to ONNX + JSON for the web replay UI.
+
+Web integration (add to Marcus' ``Watch`` screen)::
+
+    <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
+    <button id="loadPythonModelBtn">🧠 Load Trained Model (Python)</button>
+
+    const session = await ort.InferenceSession.create('export/snake_agent.onnx');
+    const input = new ort.Tensor('float32', gridData, [1, 3, gridSize, gridSize]);
+    const output = await session.run({ input });
+    const action = output.action.data[0];
+
+Persist the selected agent source in ``localStorage`` so that Marcus can toggle
+between "Browser Agent" and "Python Model (ONNX)" at runtime.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict
+
+import onnx
+import torch
+
+try:
+    from stable_baselines3 import DQN, PPO
+except ImportError as exc:  # pragma: no cover - safety net for missing deps
+    raise SystemExit("stable-baselines3 must be installed to export models") from exc
+
+
+class DQNOnnxWrapper(torch.nn.Module):
+    """Torch module that mimics the TensorFlow.js action selection logic."""
+
+    def __init__(self, policy):
+        super().__init__()
+        self.policy = policy
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        q_values = self.policy.q_net(obs)
+        action = torch.argmax(q_values, dim=1, keepdim=True)
+        return action.to(torch.int64)
+
+
+class PPOOnnxWrapper(torch.nn.Module):
+    """Torch module returning greedy actions from the PPO actor network."""
+
+    def __init__(self, policy):
+        super().__init__()
+        self.policy = policy
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        actions, _, _ = self.policy.forward(obs, deterministic=True)
+        if actions.dtype != torch.int64:
+            actions = torch.argmax(actions, dim=1, keepdim=True)
+        return actions.to(torch.int64)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export SB3 Snake models to ONNX")
+    parser.add_argument("model", type=Path, help="Path to the trained .zip model")
+    parser.add_argument("--algo", choices=["dqn", "ppo"], default="dqn")
+    parser.add_argument("--grid-size", type=int, default=15)
+    parser.add_argument("--output-dir", type=Path, default=Path("snakepython/export"))
+    return parser.parse_args()
+
+
+def load_model(path: Path, algo: str):
+    if algo == "dqn":
+        return DQN.load(path)
+    if algo == "ppo":
+        return PPO.load(path)
+    raise ValueError(f"Unsupported algorithm: {algo}")
+
+
+def export_to_onnx(model, algo: str, grid_size: int, output_path: Path) -> None:
+    dummy = torch.zeros((1, 3, grid_size, grid_size), dtype=torch.float32)
+
+    if algo == "dqn":
+        module = DQNOnnxWrapper(model.policy)
+    else:
+        module = PPOOnnxWrapper(model.policy)
+
+    module.eval()
+    module.to(torch.device("cpu"))
+    dummy = dummy.to(torch.device("cpu"))
+
+    torch.onnx.export(
+        module,
+        dummy,
+        output_path,
+        input_names=["input"],
+        output_names=["action"],
+        opset_version=17,
+        dynamic_axes={"input": {0: "batch"}, "action": {0: "batch"}},
+    )
+
+    model_proto = onnx.load(output_path)
+    meta_entries = {
+        "grid_size": str(grid_size),
+        "policy_type": model.policy.__class__.__name__,
+        "agent_type": algo.upper(),
+    }
+    model_proto.metadata_props.clear()
+    for key, value in meta_entries.items():
+        entry = model_proto.metadata_props.add()
+        entry.key = key
+        entry.value = value
+    onnx.save(model_proto, output_path)
+
+
+def export_to_json(model, algo: str, grid_size: int, json_path: Path) -> None:
+    state_dict = model.policy.state_dict()
+    serialised: Dict[str, list] = {name: tensor.cpu().numpy().tolist() for name, tensor in state_dict.items()}
+    payload = {
+        "meta": {
+            "grid_size": grid_size,
+            "policy_type": model.policy.__class__.__name__,
+            "agent_type": algo.upper(),
+        },
+        "state_dict": serialised,
+    }
+    json_path.write_text(json.dumps(payload, indent=2))
+
+
+def main() -> None:
+    args = parse_args()
+    model = load_model(args.model, args.algo)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    onnx_path = args.output_dir / "snake_agent.onnx"
+    json_path = args.output_dir / "snake_agent.json"
+
+    export_to_onnx(model, args.algo, args.grid_size, onnx_path)
+    export_to_json(model, args.algo, args.grid_size, json_path)
+
+    print(f"Exported ONNX model to {onnx_path}")
+    print(f"Exported JSON weights to {json_path}")
+    print(
+        "Web integration hint: include onnxruntime-web and load 'export/snake_agent.onnx' "
+        "from Marcus' Watch screen using the provided button callback."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/snakepython/install.sh
+++ b/snakepython/install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${PROJECT_DIR}/.venv"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[!] Python3 saknas. Installera Python 3.10 eller senare och försök igen." >&2
+  exit 1
+fi
+
+PYTHON_BIN="python3"
+if command -v python >/dev/null 2>&1; then
+  PYTHON_CANDIDATE="$(command -v python)"
+  if "${PYTHON_CANDIDATE}" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null; then
+    PYTHON_BIN="${PYTHON_CANDIDATE}"
+  fi
+fi
+
+"${PYTHON_BIN}" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' || {
+  echo "[!] Python-versionen måste vara >= 3.10" >&2
+  exit 1
+}
+
+if [ ! -d "${VENV_DIR}" ]; then
+  echo "[*] Skapar virtuell miljö i ${VENV_DIR}"
+  "${PYTHON_BIN}" -m venv "${VENV_DIR}"
+else
+  echo "[*] Virtuell miljö finns redan i ${VENV_DIR}"
+fi
+
+# Aktivera miljön
+if [ -f "${VENV_DIR}/bin/activate" ]; then
+  # shellcheck source=/dev/null
+  source "${VENV_DIR}/bin/activate"
+elif [ -f "${VENV_DIR}/Scripts/activate" ]; then
+  # shellcheck source=/dev/null
+  source "${VENV_DIR}/Scripts/activate"
+else
+  echo "[!] Kunde inte hitta aktiveringsskriptet för den virtuella miljön." >&2
+  exit 1
+fi
+
+python -m pip install --upgrade pip
+python -m pip install --upgrade wheel setuptools
+
+if [ -f "${PROJECT_DIR}/requirements.txt" ]; then
+  python -m pip install -r "${PROJECT_DIR}/requirements.txt"
+else
+  echo "[!] Hittar inte requirements.txt" >&2
+  exit 1
+fi
+
+echo "[✓] Installation klar. Aktivera miljön med:"
+echo "    source ${VENV_DIR}/bin/activate" 
+
+echo "[i] Starta en träningssession med exempelvis:"
+echo "    python train_dqn.py"

--- a/snakepython/requirements.txt
+++ b/snakepython/requirements.txt
@@ -1,0 +1,8 @@
+gymnasium>=0.29.1
+stable-baselines3>=2.3.0
+torch>=2.3.0
+numpy>=1.26
+pygame>=2.5.0
+onnx>=1.16.0
+onnxruntime>=1.18.0
+tensorboard>=2.17.0

--- a/snakepython/snake_env.py
+++ b/snakepython/snake_env.py
@@ -1,0 +1,423 @@
+"""Gymnasium environment replicating Marcus Petersson's Snake-ML HTML logic.
+
+This module mirrors the browser version by providing:
+* Grid based snake game with identical reward shaping (fruit, step, death, loop,
+  compact and wall penalties/bonuses).
+* Multiple deterministic start patterns (line, cube, edge spiral, random) just
+  like the original scripted setups Marcus used in TensorFlow.js.
+* Loop detection that punishes repeating turning patterns such as 1,2,1,2 …
+* Optional pygame rendering that shows the live training progress while
+  respecting silent vectorised environments when training several agents.
+"""
+from __future__ import annotations
+
+import math
+from collections import Counter, deque
+from dataclasses import dataclass
+from typing import Deque, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pygame
+from gymnasium import Env, spaces
+from gymnasium.utils import seeding
+
+
+Action = int
+Coordinate = Tuple[int, int]
+
+
+@dataclass
+class RewardConfig:
+    """Structured reward configuration to mirror the HTML constants."""
+
+    fruit_reward: float = 10.0
+    step_penalty: float = -0.01
+    death_penalty: float = -10.0
+    loop_penalty: float = -1.0
+    compact_bonus: float = 0.05
+    wall_penalty: float = -5.0
+
+
+class SnakeEnv(Env):
+    """Marcus Petersson's Snake-ML environment rewritten for Gymnasium.
+
+    The environment keeps the same three channel observation encoding used in the
+    browser version:
+        * Channel 0 – Snake body/head occupancy (1 where the snake lives).
+        * Channel 1 – Fruit position.
+        * Channel 2 – Normalised Manhattan distance field towards the fruit to
+          retain the compact guidance used by the original heuristics.
+
+    Rendering with pygame is optional and only enabled for the first vectorised
+    environment to avoid conflicts when running multiple training workers.
+    """
+
+    metadata = {"render_modes": ["human"], "render_fps": 8}
+
+    ACTIONS: Tuple[Coordinate, ...] = ((0, -1), (1, 0), (0, 1), (-1, 0))
+    ACTION_NAMES = {0: "UP", 1: "RIGHT", 2: "DOWN", 3: "LEFT"}
+
+    START_PATTERNS: Sequence[str] = ("line", "cube", "spiral", "random")
+
+    def __init__(
+        self,
+        grid_size: int = 15,
+        render_mode: Optional[str] = None,
+        show_window: bool = False,
+        reward_config: Optional[RewardConfig] = None,
+        seed: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+        assert 10 <= grid_size <= 20, "grid_size must be between 10 and 20"
+        self.grid_size = grid_size
+        self.reward_cfg = reward_config or RewardConfig()
+        self.render_mode = render_mode
+        self.show_window = show_window and render_mode == "human"
+
+        obs_shape = (grid_size, grid_size, 3)
+        self.observation_space = spaces.Box(
+            low=0.0, high=1.0, shape=obs_shape, dtype=np.float32
+        )
+        self.action_space = spaces.Discrete(4)
+
+        self.clock: Optional[pygame.time.Clock] = None
+        self.surface: Optional[pygame.Surface] = None
+        self.font: Optional[pygame.font.Font] = None
+
+        self.rng, _ = seeding.np_random(seed)
+        self.seed_value = seed
+
+        self.snake: List[Coordinate] = []
+        self.direction: Action = 1
+        self.pending_growth: int = 0
+        self.fruit: Coordinate = (0, 0)
+        self.steps_since_reset: int = 0
+        self.fruits_eaten: int = 0
+        self.loop_history: Deque[Action] = deque(maxlen=12)
+        self.episode_reward: float = 0.0
+
+        self._init_pygame_if_needed()
+
+    # ------------------------------------------------------------------
+    # Gymnasium API
+    # ------------------------------------------------------------------
+    def seed(self, seed: Optional[int] = None) -> None:
+        """Set deterministic seed while matching the Gymnasium protocol."""
+
+        self.rng, _ = seeding.np_random(seed)
+        self.seed_value = seed
+
+    def set_rendering(self, render_mode: Optional[str], show_window: bool) -> None:
+        """Utility used by the training scripts to toggle rendering at runtime."""
+
+        self.render_mode = render_mode
+        self.show_window = show_window and render_mode == "human"
+        if self.show_window:
+            self._init_pygame_if_needed()
+
+    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+        super().reset(seed=seed)
+        if seed is not None:
+            self.seed(seed)
+        self.steps_since_reset = 0
+        self.fruits_eaten = 0
+        self.loop_history.clear()
+        self.pending_growth = 0
+        self.episode_reward = 0.0
+        self._spawn_snake(options or {})
+        self._spawn_fruit()
+        observation = self._get_observation()
+        info = {
+            "pattern": self.start_pattern,
+            "seed": self.seed_value,
+        }
+        return observation, info
+
+    def step(self, action: Action):
+        assert self.action_space.contains(action)
+        reward = self.reward_cfg.step_penalty
+        terminated = False
+        truncated = False
+
+        if self._is_opposite_direction(action):
+            action = self.direction
+        self.direction = action
+        self.loop_history.append(action)
+
+        head_x, head_y = self.snake[0]
+        dx, dy = self.ACTIONS[action]
+        new_head = (head_x + dx, head_y + dy)
+
+        # Wall detection – grant penalty and end episode just like HTML.
+        if not self._within_bounds(new_head):
+            reward += self.reward_cfg.wall_penalty
+            reward += self.reward_cfg.death_penalty
+            terminated = True
+        else:
+            if new_head in self.snake:
+                reward += self.reward_cfg.death_penalty
+                terminated = True
+            else:
+                self.snake.insert(0, new_head)
+                if new_head == self.fruit:
+                    self.pending_growth += 1
+                    self.fruits_eaten += 1
+                    reward += self.reward_cfg.fruit_reward
+                    self._spawn_fruit()
+                if self.pending_growth > 0:
+                    self.pending_growth -= 1
+                else:
+                    self.snake.pop()
+
+        self.steps_since_reset += 1
+
+        if terminated:
+            self.episode_reward += reward
+            observation = self._get_observation()
+            info = self._build_info(done=True)
+            return observation, reward, terminated, truncated, info
+
+        reward += self._loop_penalty()
+        reward += self._compactness_bonus()
+
+        self.episode_reward += reward
+        observation = self._get_observation()
+        info = self._build_info(done=False)
+
+        if self.show_window and self.render_mode == "human":
+            self.render()
+
+        return observation, reward, terminated, truncated, info
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+    def render(self):
+        if not self.show_window or self.render_mode != "human":
+            return
+
+        if self.surface is None:
+            self._init_pygame_if_needed()
+
+        cell_size = 28
+        margin = 20
+        width = self.grid_size * cell_size + margin * 2
+        height = self.grid_size * cell_size + margin * 2
+        screen = self.surface
+        screen.fill((15, 15, 30))
+
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                self.close()
+                return
+
+        for x in range(self.grid_size):
+            for y in range(self.grid_size):
+                rect = pygame.Rect(
+                    margin + x * cell_size,
+                    margin + y * cell_size,
+                    cell_size,
+                    cell_size,
+                )
+                pygame.draw.rect(screen, (30, 30, 50), rect, 1)
+
+        for i, (sx, sy) in enumerate(self.snake):
+            color = (60, 200, 120) if i else (230, 240, 90)
+            rect = pygame.Rect(
+                margin + sx * cell_size,
+                margin + sy * cell_size,
+                cell_size,
+                cell_size,
+            )
+            pygame.draw.rect(screen, color, rect)
+
+        fx, fy = self.fruit
+        fruit_rect = pygame.Rect(
+            margin + fx * cell_size,
+            margin + fy * cell_size,
+            cell_size,
+            cell_size,
+        )
+        pygame.draw.rect(screen, (220, 90, 110), fruit_rect)
+
+        status = (
+            f"Snake-ML | Pattern: {self.start_pattern} | "
+            f"Fruits: {self.fruits_eaten} | Steps: {self.steps_since_reset}"
+        )
+        pygame.display.set_caption(status)
+
+        if self.font:
+            text_surf = self.font.render(status, True, (220, 220, 220))
+            screen.blit(text_surf, (margin, 4))
+
+        pygame.display.flip()
+        self.clock.tick(self.metadata["render_fps"])
+
+    def close(self):
+        if self.surface is not None:
+            pygame.display.quit()
+            pygame.quit()
+            self.surface = None
+            self.clock = None
+            self.font = None
+            self.show_window = False
+
+    # ------------------------------------------------------------------
+    # Internal helpers mirroring the JS version
+    # ------------------------------------------------------------------
+    def _init_pygame_if_needed(self) -> None:
+        if not self.show_window:
+            return
+        if not pygame.get_init():
+            pygame.init()
+        self.clock = pygame.time.Clock()
+        window_size = (self.grid_size * 28 + 40, self.grid_size * 28 + 40)
+        self.surface = pygame.display.set_mode(window_size)
+        try:
+            pygame.font.init()
+            self.font = pygame.font.SysFont("consolas", 16)
+        except Exception:
+            self.font = None
+
+    def _spawn_snake(self, options: dict) -> None:
+        pattern = options.get("pattern") or str(self.rng.choice(np.array(self.START_PATTERNS)))
+        self.start_pattern = pattern
+        cx = self.grid_size // 2
+        cy = self.grid_size // 2
+
+        if pattern == "line":
+            length = max(3, self.grid_size // 3)
+            start_x = int(np.clip(cx - length // 2, 1, self.grid_size - length - 1))
+            self.snake = [(start_x + i, cy) for i in range(length)]
+            self.direction = 1
+        elif pattern == "cube":
+            half = max(2, self.grid_size // 4)
+            points: List[Coordinate] = []
+            for dy in range(-half, half):
+                for dx in range(-half, half):
+                    nx = int(np.clip(cx + dx, 1, self.grid_size - 2))
+                    ny = int(np.clip(cy + dy, 1, self.grid_size - 2))
+                    points.append((nx, ny))
+            self.snake = list(dict.fromkeys(points))
+            self.direction = 1
+        elif pattern == "spiral":
+            self.snake = self._generate_spiral(cx, cy)
+            self.direction = 0
+        else:  # random scatter
+            length = max(4, self.grid_size // 2)
+            self.snake = []
+            used = set()
+            while len(self.snake) < length:
+                pos = (self.rng.integers(1, self.grid_size - 1), self.rng.integers(1, self.grid_size - 1))
+                if pos not in used:
+                    self.snake.append(pos)
+                    used.add(pos)
+            self.snake.sort()
+            self.direction = int(self.rng.integers(0, 4))
+
+        self.snake = [self._wrap_position(p) for p in self.snake]
+
+    def _spawn_fruit(self) -> None:
+        available = set((x, y) for x in range(self.grid_size) for y in range(self.grid_size))
+        for segment in self.snake:
+            available.discard(segment)
+        if not available:
+            self.fruit = self.snake[0]
+            return
+        options = list(available)
+        idx = int(self.rng.integers(0, len(options)))
+        self.fruit = options[idx]
+
+    def _generate_spiral(self, cx: int, cy: int) -> List[Coordinate]:
+        path: List[Coordinate] = []
+        radius = min(cx, cy) - 1
+        x, y = cx, cy
+        directions = [(1, 0), (0, 1), (-1, 0), (0, -1)]
+        step_length = 1
+        while radius > 0 and len(path) < self.grid_size * self.grid_size:
+            for d in directions:
+                for _ in range(step_length):
+                    x += d[0]
+                    y += d[1]
+                    if not self._within_bounds((x, y)):
+                        continue
+                    path.append((x, y))
+                step_length += 1
+            radius -= 1
+        if not path:
+            path = [(cx, cy)]
+        return path[: max(3, self.grid_size // 2)]
+
+    def _get_observation(self) -> np.ndarray:
+        grid = np.zeros((self.grid_size, self.grid_size, 3), dtype=np.float32)
+        for i, (x, y) in enumerate(self.snake):
+            grid[y, x, 0] = 1.0 if i else 0.75
+        fx, fy = self.fruit
+        grid[fy, fx, 1] = 1.0
+        self._encode_distance_field(grid)
+        return grid
+
+    def _encode_distance_field(self, grid: np.ndarray) -> None:
+        fx, fy = self.fruit
+        norm = self.grid_size * 2
+        for y in range(self.grid_size):
+            for x in range(self.grid_size):
+                dist = abs(fx - x) + abs(fy - y)
+                grid[y, x, 2] = 1.0 - dist / norm
+
+    def _within_bounds(self, pos: Coordinate) -> bool:
+        x, y = pos
+        return 0 <= x < self.grid_size and 0 <= y < self.grid_size
+
+    def _is_opposite_direction(self, action: Action) -> bool:
+        return (self.direction + 2) % 4 == action
+
+    def _wrap_position(self, pos: Coordinate) -> Coordinate:
+        x, y = pos
+        return (int(np.clip(x, 0, self.grid_size - 1)), int(np.clip(y, 0, self.grid_size - 1)))
+
+    def _compactness_bonus(self) -> float:
+        cx = cy = self.grid_size / 2
+        head_x, head_y = self.snake[0]
+        distance = math.hypot(head_x - cx, head_y - cy)
+        max_distance = math.hypot(cx, cy)
+        compact_score = 1.0 - (distance / max_distance)
+        return self.reward_cfg.compact_bonus * compact_score
+
+    def _loop_penalty(self) -> float:
+        penalty = 0.0
+        pattern = self._detect_loop_pattern(self.loop_history)
+        if pattern:
+            penalty += self.reward_cfg.loop_penalty
+        return penalty
+
+    def _detect_loop_pattern(self, history: Deque[Action]) -> Optional[Tuple[Action, ...]]:
+        if len(history) < 6:
+            return None
+        counts = Counter(history)
+        if len(counts) <= 2:
+            seq = tuple(history)
+            if all(seq[i] == seq[i % 2] for i in range(len(seq))):
+                return seq[:2]
+        if len(history) >= 8:
+            seq = tuple(history)
+            half = len(seq) // 2
+            if seq[:half] == seq[half:]:
+                return seq[:half]
+        return None
+
+    def _build_info(self, done: bool) -> dict:
+        info = {
+            "fruits": self.fruits_eaten,
+            "steps": self.steps_since_reset,
+            "pattern": self.start_pattern,
+        }
+        if done:
+            info["episode"] = {
+                "r": float(self.episode_reward),
+                "l": self.steps_since_reset,
+            }
+        return info
+
+
+__all__ = ["SnakeEnv", "RewardConfig"]

--- a/snakepython/train_dqn.py
+++ b/snakepython/train_dqn.py
@@ -1,0 +1,153 @@
+"""DQN training entry point that mirrors Marcus Petersson's HTML Snake-ML loop.
+
+Key features carried over from the original browser implementation:
+* Identical reward shaping via :class:`snake_env.SnakeEnv`.
+* Real-time pygame rendering for the first vectorised environment while the
+  remaining environments run silently in the background.
+* Periodic logging of reward, episode length and fruits collected.
+* Optional TensorBoard summaries at ``./tb_snake`` to match the JavaScript UI.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+from pathlib import Path
+from typing import List
+
+import numpy as np
+from stable_baselines3 import DQN
+from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.env_util import make_vec_env
+from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv
+
+from snake_env import SnakeEnv
+
+ANSI_GREEN = "\033[92m"
+ANSI_YELLOW = "\033[93m"
+ANSI_RESET = "\033[0m"
+
+
+class EpisodeTracker(BaseCallback):
+    """Collect metrics and print Marcus-style coloured console updates."""
+
+    def __init__(self, log_interval: int = 10_000):
+        super().__init__(verbose=1)
+        self.log_interval = log_interval
+        self.episode_rewards: List[float] = []
+        self.episode_lengths: List[int] = []
+        self.episode_fruits: List[int] = []
+        self.last_log_step = 0
+
+    def _on_step(self) -> bool:
+        infos = self.locals.get("infos", [])
+        for info in infos:
+            if not info:
+                continue
+            if "episode" in info:
+                self.episode_rewards.append(info["episode"]["r"])
+                self.episode_lengths.append(info["episode"]["l"])
+                self.episode_fruits.append(info.get("fruits", 0))
+                self.logger.record("rollout/fruits", info.get("fruits", 0))
+                coloured = f"{ANSI_GREEN if info['episode']['r'] > 0 else ANSI_YELLOW}"  # noqa: E501
+                print(
+                    f"{coloured}Episode | Reward: {info['episode']['r']:.2f} | "
+                    f"Length: {info['episode']['l']} | Fruits: {info.get('fruits', 0)}{ANSI_RESET}"
+                )
+
+        if self.num_timesteps - self.last_log_step >= self.log_interval:
+            self.last_log_step = self.num_timesteps
+            if self.episode_rewards:
+                mean_r = float(np.mean(self.episode_rewards[-20:]))
+                mean_l = float(np.mean(self.episode_lengths[-20:]))
+                mean_f = float(np.mean(self.episode_fruits[-20:]))
+                self.logger.record("snake/avg_reward_20", mean_r)
+                self.logger.record("snake/avg_length_20", mean_l)
+                self.logger.record("snake/avg_fruits_20", mean_f)
+                print(
+                    f"{ANSI_GREEN}Step {self.num_timesteps:,} | Avg Reward (20 ep): {mean_r:.2f} | "
+                    f"Avg Len: {mean_l:.1f} | Avg Fruits: {mean_f:.2f}{ANSI_RESET}"
+                )
+        return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a DQN Snake agent")
+    parser.add_argument("--timesteps", type=int, default=500_000, help="Total training timesteps")
+    parser.add_argument("--grid-size", type=int, default=15, help="Snake grid size")
+    parser.add_argument("--tensorboard", action="store_true", help="Enable TensorBoard logging")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("--run-name", type=str, default=None, help="Custom run identifier used for saved models and logs")
+    parser.add_argument("--headless", action="store_true", help="Disable pygame rendering (useful for batch jobs)")
+    return parser.parse_args()
+
+
+def build_vector_env(grid_size: int, n_envs: int, seed: int, render_first_env: bool) -> VecEnv:
+    """Create an 8-env vector with optional pygame rendering for env[0]."""
+
+    env_kwargs = {"grid_size": grid_size, "render_mode": None, "show_window": False}
+    vec_env = make_vec_env(
+        lambda: SnakeEnv(**env_kwargs),
+        n_envs=n_envs,
+        seed=seed,
+        monitor_dir=None,
+        vec_env_cls=DummyVecEnv,
+    )
+
+    # Activate rendering for the first environment only to avoid pygame clashes.
+    if render_first_env:
+        vec_env.env_method("set_rendering", render_mode="human", show_window=True, indices=[0])
+    return vec_env
+
+
+def main() -> None:
+    args = parse_args()
+
+    models_dir = Path("snakepython") / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+
+    vec_env = build_vector_env(args.grid_size, n_envs=8, seed=args.seed, render_first_env=not args.headless)
+
+    policy_kwargs = dict(net_arch=[256, 256])
+    if args.tensorboard:
+        if args.run_name:
+            tb_path = Path("snakepython") / "tb_snake" / args.run_name
+        else:
+            tb_path = Path("snakepython") / "tb_snake"
+        tb_path.mkdir(parents=True, exist_ok=True)
+        tensorboard_log = str(tb_path)
+    else:
+        tensorboard_log = None
+
+    model = DQN(
+        "CnnPolicy",
+        vec_env,
+        verbose=1,
+        learning_starts=10_000,
+        buffer_size=100_000,
+        exploration_fraction=0.2,
+        exploration_final_eps=0.02,
+        batch_size=256,
+        target_update_interval=1_000,
+        tensorboard_log=tensorboard_log,
+        policy_kwargs=policy_kwargs,
+        seed=args.seed,
+    )
+
+    callback = EpisodeTracker()
+
+    try:
+        model.learn(total_timesteps=args.timesteps, callback=callback, log_interval=1)
+    finally:
+        if args.run_name:
+            filename = f"dqn_snake_{args.run_name}.zip"
+        else:
+            timestamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f"dqn_snake_{timestamp}.zip"
+        model_path = models_dir / filename
+        model.save(model_path)
+        print(f"Saved model to {model_path}")
+        vec_env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/snakepython/train_ppo.py
+++ b/snakepython/train_ppo.py
@@ -1,0 +1,138 @@
+"""PPO training script offering an alternative to Marcus Petersson's DQN agent."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+from pathlib import Path
+
+import numpy as np
+from stable_baselines3 import PPO
+from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.env_util import make_vec_env
+from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv
+
+from snake_env import SnakeEnv
+
+ANSI_GREEN = "\033[92m"
+ANSI_YELLOW = "\033[93m"
+ANSI_RESET = "\033[0m"
+
+
+class EpisodeTracker(BaseCallback):
+    """Shared callback for PPO mirroring console telemetry from the web UI."""
+
+    def __init__(self, log_interval: int = 10_000):
+        super().__init__(verbose=1)
+        self.log_interval = log_interval
+        self.rewards: list[float] = []
+        self.lengths: list[int] = []
+        self.fruits: list[int] = []
+        self.last_log = 0
+
+    def _on_step(self) -> bool:
+        infos = self.locals.get("infos", [])
+        for info in infos:
+            if not info:
+                continue
+            if "episode" in info:
+                self.rewards.append(info["episode"]["r"])
+                self.lengths.append(info["episode"]["l"])
+                self.fruits.append(info.get("fruits", 0))
+                self.logger.record("rollout/fruits", info.get("fruits", 0))
+                colour = ANSI_GREEN if info["episode"]["r"] > 0 else ANSI_YELLOW
+                print(
+                    f"{colour}Episode | Reward: {info['episode']['r']:.2f} | "
+                    f"Length: {info['episode']['l']} | Fruits: {info.get('fruits', 0)}{ANSI_RESET}"
+                )
+
+        if self.num_timesteps - self.last_log >= self.log_interval:
+            self.last_log = self.num_timesteps
+            if self.rewards:
+                avg_r = float(np.mean(self.rewards[-20:]))
+                avg_l = float(np.mean(self.lengths[-20:]))
+                avg_f = float(np.mean(self.fruits[-20:]))
+                self.logger.record("snake/avg_reward_20", avg_r)
+                self.logger.record("snake/avg_length_20", avg_l)
+                self.logger.record("snake/avg_fruits_20", avg_f)
+                print(
+                    f"{ANSI_GREEN}Step {self.num_timesteps:,} | Avg Reward (20 ep): {avg_r:.2f} | "
+                    f"Avg Len: {avg_l:.1f} | Avg Fruits: {avg_f:.2f}{ANSI_RESET}"
+                )
+        return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a PPO Snake agent")
+    parser.add_argument("--timesteps", type=int, default=500_000)
+    parser.add_argument("--grid-size", type=int, default=15)
+    parser.add_argument("--tensorboard", action="store_true")
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--run-name", type=str, default=None)
+    parser.add_argument("--headless", action="store_true")
+    return parser.parse_args()
+
+
+def build_vector_env(grid_size: int, n_envs: int, seed: int, render_first_env: bool) -> VecEnv:
+    env_kwargs = {"grid_size": grid_size, "render_mode": None, "show_window": False}
+    vec_env = make_vec_env(
+        lambda: SnakeEnv(**env_kwargs),
+        n_envs=n_envs,
+        seed=seed,
+        monitor_dir=None,
+        vec_env_cls=DummyVecEnv,
+    )
+    if render_first_env:
+        vec_env.env_method("set_rendering", render_mode="human", show_window=True, indices=[0])
+    return vec_env
+
+
+def main() -> None:
+    args = parse_args()
+    models_dir = Path("snakepython") / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+
+    vec_env = build_vector_env(args.grid_size, n_envs=8, seed=args.seed, render_first_env=not args.headless)
+
+    if args.tensorboard:
+        if args.run_name:
+            tb_path = Path("snakepython") / "tb_snake" / args.run_name
+        else:
+            tb_path = Path("snakepython") / "tb_snake"
+        tb_path.mkdir(parents=True, exist_ok=True)
+        tensorboard_log = str(tb_path)
+    else:
+        tensorboard_log = None
+
+    model = PPO(
+        "CnnPolicy",
+        vec_env,
+        learning_rate=3e-4,
+        gamma=0.975,
+        gae_lambda=0.92,
+        clip_range=0.2,
+        n_steps=2048,
+        ent_coef=0.01,
+        vf_coef=0.5,
+        verbose=1,
+        seed=args.seed,
+        tensorboard_log=tensorboard_log,
+    )
+
+    callback = EpisodeTracker()
+
+    try:
+        model.learn(total_timesteps=args.timesteps, callback=callback)
+    finally:
+        if args.run_name:
+            filename = f"ppo_snake_{args.run_name}.zip"
+        else:
+            timestamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f"ppo_snake_{timestamp}.zip"
+        model_path = models_dir / filename
+        model.save(model_path)
+        print(f"Saved PPO model to {model_path}")
+        vec_env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/snakepython/utils/run_multi_train.py
+++ b/snakepython/utils/run_multi_train.py
@@ -1,0 +1,97 @@
+"""Utility to launch multiple Snake training jobs in parallel processes."""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from threading import Thread
+from typing import List
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def stream_output(process: subprocess.Popen, prefix: str) -> None:
+    """Forward child stdout to the console with a helpful prefix."""
+
+    assert process.stdout is not None
+    for line in process.stdout:
+        print(f"[{prefix}] {line.rstrip()}")
+    process.stdout.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Launch multiple Snake training runs")
+    parser.add_argument("--runs", type=int, default=4, help="Number of parallel runs")
+    parser.add_argument("--algo", choices=["dqn", "ppo"], default="dqn", help="Algorithm to train")
+    parser.add_argument("--timesteps", type=int, default=500_000, help="Timesteps per run")
+    parser.add_argument("--grid-size", type=int, default=15, help="Environment grid size")
+    parser.add_argument("--tensorboard", action="store_true", help="Enable TensorBoard logging")
+    parser.add_argument("--base-seed", type=int, default=100, help="Seed offset for reproducibility")
+    parser.add_argument("--headless", action="store_true", help="Disable pygame windows in all runs")
+    return parser.parse_args()
+
+
+def build_command(args: argparse.Namespace, run_index: int) -> List[str]:
+    script = ROOT / f"train_{args.algo}.py"
+    run_name = f"run{run_index}"
+    seed = args.base_seed + run_index
+
+    command = [
+        sys.executable,
+        str(script),
+        "--timesteps",
+        str(args.timesteps),
+        "--grid-size",
+        str(args.grid_size),
+        "--seed",
+        str(seed),
+        "--run-name",
+        run_name,
+    ]
+
+    if args.tensorboard:
+        command.append("--tensorboard")
+    if args.headless:
+        command.append("--headless")
+
+    return command
+
+
+def main() -> None:
+    args = parse_args()
+    processes: List[subprocess.Popen] = []
+
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+
+    for run in range(1, args.runs + 1):
+        command = build_command(args, run)
+        print(f"Starting run {run}: {' '.join(command)}")
+        proc = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+            text=True,
+            cwd=str(ROOT),
+            env=env,
+        )
+        processes.append(proc)
+        Thread(target=stream_output, args=(proc, f"{args.algo.upper()}-{run}"), daemon=True).start()
+
+    exit_code = 0
+    for run, proc in enumerate(processes, start=1):
+        ret = proc.wait()
+        if ret != 0:
+            print(f"Run {run} exited with code {ret}")
+            exit_code = ret
+        else:
+            print(f"Run {run} completed successfully")
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update DQN and PPO trainers to import make_vec_env from the supported stable-baselines3 location
- extend the README with Windows/IDLE usage guidance and correct the headless flag documentation

## Testing
- python -m compileall snakepython

------
https://chatgpt.com/codex/tasks/task_e_68e541d17e3c8324b6b178daf9233408