### PR TITLE
Allow configuring parallel Snake training environments

### DIFF
--- a/snakepython/README.md
+++ b/snakepython/README.md
@@ -68,7 +68,7 @@ pip install -r requirements.txt
 
 | Script | Beskrivning | Standardparametrar |
 | ------ | ----------- | ------------------ |
-| `train_dqn.py` | Tränar en DQN-agent med åtta parallella miljöer. Renderar miljö 0 i realtid. | 500 000 steg, `CnnPolicy`, `tensorboard_log="./tb_snake/"` när flaggan används. |
+| `train_dqn.py` | Tränar en DQN-agent med valfritt antal parallella miljöer (`--parallel-envs`). Renderar miljö 0 i realtid. | 500 000 steg, `CnnPolicy`, `tensorboard_log="./tb_snake/"` när flaggan används. |
 | `train_ppo.py` | Tränar en PPO-agent med samma miljö och motsvarande loggning. | `learning_rate=3e-4`, `gamma=0.975`, `n_steps=2048`, m.fl. |
 
 Samtliga skript tar emot följande vanliga flaggor:
@@ -77,6 +77,7 @@ Samtliga skript tar emot följande vanliga flaggor:
 * `--grid-size <int>` – rutnätsstorlek (10–20 rekommenderas).
 * `--tensorboard` – aktivera TensorBoard-loggar.
 * `--seed <int>` – sätt slumpfrö.
+* `--parallel-envs <int>` – antal miljöer som körs samtidigt (standard 8).
 
 ### Multi-run launcher
 

--- a/snakepython/train_dqn.py
+++ b/snakepython/train_dqn.py
@@ -76,6 +76,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--grid-size", type=int, default=15, help="Snake grid size")
     parser.add_argument("--tensorboard", action="store_true", help="Enable TensorBoard logging")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument(
+        "--parallel-envs",
+        type=int,
+        default=8,
+        help="Number of simultaneous environments to train on",
+    )
     parser.add_argument("--run-name", type=str, default=None, help="Custom run identifier used for saved models and logs")
     parser.add_argument("--headless", action="store_true", help="Disable pygame rendering (useful for batch jobs)")
     return parser.parse_args()
@@ -105,7 +111,13 @@ def main() -> None:
     models_dir = Path("snakepython") / "models"
     models_dir.mkdir(parents=True, exist_ok=True)
 
-    vec_env = build_vector_env(args.grid_size, n_envs=8, seed=args.seed, render_first_env=not args.headless)
+    n_envs = max(1, int(args.parallel_envs))
+    vec_env = build_vector_env(
+        args.grid_size,
+        n_envs=n_envs,
+        seed=args.seed,
+        render_first_env=not args.headless,
+    )
 
     policy_kwargs = dict(net_arch=[256, 256])
     if args.tensorboard:

--- a/snakepython/train_ppo.py
+++ b/snakepython/train_ppo.py
@@ -67,6 +67,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--grid-size", type=int, default=15)
     parser.add_argument("--tensorboard", action="store_true")
     parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument(
+        "--parallel-envs",
+        type=int,
+        default=8,
+        help="Number of simultaneous environments to train on",
+    )
     parser.add_argument("--run-name", type=str, default=None)
     parser.add_argument("--headless", action="store_true")
     return parser.parse_args()
@@ -91,7 +97,13 @@ def main() -> None:
     models_dir = Path("snakepython") / "models"
     models_dir.mkdir(parents=True, exist_ok=True)
 
-    vec_env = build_vector_env(args.grid_size, n_envs=8, seed=args.seed, render_first_env=not args.headless)
+    n_envs = max(1, int(args.parallel_envs))
+    vec_env = build_vector_env(
+        args.grid_size,
+        n_envs=n_envs,
+        seed=args.seed,
+        render_first_env=not args.headless,
+    )
 
     if args.tensorboard:
         if args.run_name:


### PR DESCRIPTION
## Summary
- allow passing a `--parallel-envs` argument to the DQN and PPO training scripts to control how many environments run simultaneously
- document the new flag in the Python README so users know how to launch multiple parallel trainings

## Testing
- python -m compileall snakepython/train_dqn.py snakepython/train_ppo.py

------
https://chatgpt.com/codex/tasks/task_e_68e568fbe75483248ba292150ca7103c