### PR TITLE
Fix backward pass to use pre-update weights

### DIFF
--- a/snakepython/idle_snake.py
+++ b/snakepython/idle_snake.py
@@ -204,13 +204,14 @@ class MLP:
         grad = grad_output
         for layer in reversed(range(len(self.weights))):
             a_prev = activations[layer]
+            weight = self.weights[layer]
             grad_w = a_prev.T @ grad
             grad_b = grad.sum(axis=0)
+            if layer > 0:
+                grad = grad @ weight.T
+                grad = grad * (pre_activations[layer - 1] > 0)
             self.weights[layer] -= learning_rate * grad_w
             self.biases[layer] -= learning_rate * grad_b
-            if layer > 0:
-                grad = grad @ self.weights[layer].T
-                grad = grad * (pre_activations[layer - 1] > 0)
 
     def copy(self) -> "MLP":
         clone = MLP(self.layer_sizes)


### PR DESCRIPTION
## Summary
- ensure the MLP backward pass caches the weight matrix before computing gradients
- defer weight and bias updates until after backpropagating to the previous layer

## Testing
- python snakepython/idle_snake.py --train 10 --steps 200

------
https://chatgpt.com/codex/tasks/task_e_68e56bc70d848324a0e2ea4ca34d8534