### PR TITLE
Enhance snake visuals and reward controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,24 @@
 body{
   margin:0;
   min-height:100vh;
-  background:radial-gradient(160% 140% at 20% -20%,#202866 0%,#131834 45%,#090d1f 100%);
+  background:#030915;
   color:var(--ink);
   font:14px/1.5 "Inter","Segoe UI",Roboto,sans-serif;
+  position:relative;
+  overflow-x:hidden;
+}
+body::before{
+  content:"";
+  position:fixed;
+  inset:0;
+  z-index:-1;
+  background:
+    radial-gradient(120% 80% at 15% 15%,rgba(59,130,246,0.35) 0%,rgba(59,130,246,0) 65%),
+    radial-gradient(90% 90% at 85% 20%,rgba(34,197,94,0.25) 0%,rgba(13,148,136,0) 70%),
+    radial-gradient(120% 120% at 50% 110%,rgba(147,51,234,0.25) 0%,rgba(15,23,42,0) 70%),
+    linear-gradient(135deg,#07121c 0%,#0a1f24 38%,#0f2c1c 100%);
+  filter:saturate(1.2);
+  pointer-events:none;
 }
 header{
   padding:20px 0;
@@ -149,9 +164,11 @@ h2{
   width:100%;
   aspect-ratio:1/1;
   border-radius:26px;
-  background:radial-gradient(140% 140% at 30% 20%,#273067 0%,#151a3a 50%,#0d1127 100%);
-  border:1px solid rgba(128,140,210,0.25);
-  box-shadow:0 40px 80px rgba(8,12,42,0.55);
+  background:radial-gradient(150% 140% at 28% 18%,#0d2a2a 0%,#071621 52%,#040b15 100%);
+  border:1px solid rgba(34,197,94,0.18);
+  box-shadow:0 40px 90px rgba(4,12,24,0.6);
+  position:relative;
+  overflow:hidden;
 }
 .controls{
   display:flex;
@@ -1145,6 +1162,11 @@ footer{
         <button type="button" class="pill" data-speed="turbo">Turbo</button>
       </div>
       <div class="field compact">
+        <label for="liveSpeed">Live speed</label>
+        <input type="range" id="liveSpeed" min="30" max="200" step="5" value="110">
+        <span class="mono" id="liveSpeedReadout">110&nbsp;ms</span>
+      </div>
+      <div class="field compact">
         <label for="gridSize">Board size</label>
         <input type="range" id="gridSize" min="10" max="30" step="1" value="20">
         <span class="mono" id="gridLabel">20×20</span>
@@ -1457,10 +1479,17 @@ footer{
             <input type="range" id="rewardGrowth" min="0" max="50" step="0.1" value="1.0">
             <span class="mono" id="rewardGrowthReadout">1.0</span>
           </label>
-          <label>Compactness bonus
-            <span class="hint">Rewards tighter body packing inside the bounding box.</span>
+          <label>Compactness weight
+            <span class="hint">Scales how strongly compact shapes influence the reward.</span>
             <input type="range" id="rewardCompact" min="0" max="5.0" step="0.001" value="0.000">
             <span class="mono" id="rewardCompactReadout">0.000</span>
+          </label>
+        </div>
+        <div class="row">
+          <label>Compactness bonus
+            <span class="hint">Sets the actual bonus applied when the body stays tight.</span>
+            <input type="range" id="rewardCompactBonus" min="0" max="1.5" step="0.01" value="0.25">
+            <span class="mono" id="rewardCompactBonusReadout">0.25</span>
           </label>
         </div>
       </div>
@@ -1478,6 +1507,13 @@ footer{
           Hamilton Weight:
           <input type="range" id="hamSlider" min="0" max="10" step="0.01" value="0.05">
           <span id="hamVal">0.05</span>
+        </label><br>
+
+        <label>
+          Helper Alignment Penalty:
+          <span class="hint">Penalty applied when the agent ignores planner guidance.</span>
+          <input type="range" id="rewardHelperPenalty" min="0" max="5" step="0.05" value="0.25">
+          <span class="mono" id="rewardHelperPenaltyReadout">0.25</span>
         </label><br>
 
         <label>
@@ -1898,6 +1934,7 @@ const REWARD_LABELS={
   growthBonus:'Growth bonus',
   compactWeight:'Compactness weight',
   compactness:'Compactness bonus',
+  compactBonus:'Compactness bonus',
   bfsHelper:'BFS helper bonus',
   hamiltonHelper:'Hamilton helper bonus',
   bfsWeight:'BFS helper weight',
@@ -1921,9 +1958,11 @@ const REWARD_INPUT_IDS={
   fruitReward:'rewardFruit',
   growthBonus:'rewardGrowth',
   compactWeight:'rewardCompact',
+  compactBonus:'rewardCompactBonus',
   bfsWeight:'bfsSlider',
   hamiltonWeight:'hamSlider',
   usePathHelpers:'usePathHelpers',
+  helperAlignmentPenalty:'rewardHelperPenalty',
 };
 const RECENT_EPISODES_MAX=32;
 const ROLLUP_WINDOW=1000;
@@ -4128,12 +4167,14 @@ const cloneState=state=>({
   fruit:{x:state.fruit.x,y:state.fruit.y},
   pattern:state.pattern||null,
 });
-const BG_COLOR='#101532';
-const GRID_COLOR='rgba(135,143,210,0.16)';
-const HEAD_GRADIENT=['#f472b6','#c084fc'];
-const BODY_GRADIENT=['#8b5cf6','#6366f1'];
-const HEAD_GLOW='rgba(244,114,182,0.65)';
-const BODY_GLOW='rgba(99,102,241,0.5)';
+const BG_COLOR='#04101a';
+const GRID_COLOR='rgba(148,255,223,0.12)';
+const HEAD_GRADIENT=['#34d399','#047857'];
+const BODY_GRADIENT=['#22c55e','#065f46'];
+const HEAD_GLOW='rgba(52,211,153,0.55)';
+const BODY_GLOW='rgba(16,185,129,0.45)';
+const HEAD_STROKE='rgba(134,239,172,0.9)';
+const BODY_STROKE='rgba(21,128,61,0.65)';
 let lastDrawnState=snapshotEnv(env);
 let renderQueue=[];
 let currentAnim=null;
@@ -4288,35 +4329,143 @@ function drawFruit(fruit,alpha=1){
   bctx.beginPath();
   bctx.arc(cx,cy,radius,0,Math.PI*2);
   bctx.fill();
+  bctx.shadowBlur=0;
+  const leafGradient=bctx.createLinearGradient(cx,cy-radius,cx+radius*0.4,cy-radius*1.4);
+  leafGradient.addColorStop(0,`rgba(34,197,94,${alpha})`);
+  leafGradient.addColorStop(1,`rgba(14,116,144,${alpha*0.6})`);
+  bctx.fillStyle=leafGradient;
+  bctx.beginPath();
+  bctx.moveTo(cx-radius*0.1,cy-radius*0.8);
+  bctx.quadraticCurveTo(cx+radius*0.8,cy-radius*1.4,cx+radius*0.25,cy-radius*1.65);
+  bctx.quadraticCurveTo(cx-radius*0.4,cy-radius*1.25,cx-radius*0.15,cy-radius*0.85);
+  bctx.closePath();
+  bctx.fill();
   bctx.restore();
 }
 function drawSnakeSegments(segments){
   if(!segments.length) return;
   bctx.save();
+  bctx.lineJoin='round';
+  const head=segments[0];
+  const neck=segments[1]||head;
   segments.forEach((seg,i)=>{
-    const colors=i===0?HEAD_GRADIENT:BODY_GRADIENT;
-    const glow=i===0?HEAD_GLOW:BODY_GLOW;
-    const size=CELL*0.74;
+    const isHead=i===0;
+    const colors=isHead?HEAD_GRADIENT:BODY_GRADIENT;
+    const glow=isHead?HEAD_GLOW:BODY_GLOW;
+    const size=isHead?CELL*0.84:CELL*0.74;
     const offset=(CELL-size)/2;
-    const radius=Math.min(size*0.45,12);
+    const radius=Math.min(size*0.48,14);
     const x=seg.x*CELL+offset;
     const y=seg.y*CELL+offset;
     const gradient=bctx.createLinearGradient(x,y,x,y+size);
     gradient.addColorStop(0,colors[0]);
     gradient.addColorStop(1,colors[1]);
-    bctx.shadowBlur=i===0?18:12;
+    bctx.shadowBlur=isHead?26:14;
     bctx.shadowColor=glow;
     bctx.fillStyle=gradient;
-    drawRoundedRect(x,y,size,size,radius);
+    fillRoundedRect(x,y,size,size,radius);
     bctx.shadowBlur=0;
-    const highlight=bctx.createRadialGradient(x+size*0.35,y+size*0.35,0,x+size*0.35,y+size*0.35,size*0.9);
-    highlight.addColorStop(0,'rgba(255,255,255,0.32)');
-    highlight.addColorStop(1,'rgba(255,255,255,0)');
-    bctx.fillStyle=highlight;
-    drawRoundedRect(x,y,size,size,radius);
+    const sheen=bctx.createRadialGradient(x+size*0.6,y+size*0.35,0,x+size*0.6,y+size*0.35,size*0.95);
+    sheen.addColorStop(0,'rgba(255,255,255,0.22)');
+    sheen.addColorStop(0.55,'rgba(255,255,255,0.08)');
+    sheen.addColorStop(1,'rgba(255,255,255,0)');
+    bctx.fillStyle=sheen;
+    fillRoundedRect(x,y,size,size,radius);
+    const belly=bctx.createLinearGradient(x,y+size*0.25,x,y+size);
+    belly.addColorStop(0,'rgba(255,255,255,0)');
+    belly.addColorStop(1,'rgba(203,255,198,0.28)');
+    bctx.fillStyle=belly;
+    fillRoundedRect(x,y,size,size,radius);
+    bctx.lineWidth=isHead?2.2:1.4;
+    bctx.strokeStyle=isHead?HEAD_STROKE:BODY_STROKE;
+    strokeRoundedRect(x,y,size,size,radius);
   });
+  drawSnakeHeadDetails(head,neck);
   bctx.restore();
 }
+
+function drawSnakeHeadDetails(head,neck){
+  if(!head) return;
+  const size=CELL*0.84;
+  const offset=(CELL-size)/2;
+  const cx=head.x*CELL+offset+size/2;
+  const cy=head.y*CELL+offset+size/2;
+  const nx=neck?.x??head.x;
+  const ny=neck?.y??head.y;
+  const dirX=head.x-nx;
+  const dirY=head.y-ny;
+  const angle=Math.atan2(dirY,dirX)||0;
+  const cos=Math.cos(angle);
+  const sin=Math.sin(angle);
+  const perpX=-sin;
+  const perpY=cos;
+  const eyeForward=size*0.26;
+  const eyeSpread=size*0.18;
+  const eyeRadius=size*0.09;
+  const pupilRadius=eyeRadius*0.45;
+  const pupilOffset=size*0.05;
+  const eyeBaseX=cx+cos*eyeForward;
+  const eyeBaseY=cy+sin*eyeForward;
+  bctx.save();
+  const eyes=[1,-1].map(sign=>({
+    x:eyeBaseX+perpX*eyeSpread*sign,
+    y:eyeBaseY+perpY*eyeSpread*sign,
+  }));
+  eyes.forEach(({x,y})=>{
+    bctx.fillStyle='rgba(255,255,255,0.96)';
+    bctx.beginPath();
+    bctx.arc(x,y,eyeRadius,0,Math.PI*2);
+    bctx.fill();
+    bctx.fillStyle='rgba(30,64,175,0.85)';
+    bctx.beginPath();
+    bctx.arc(x+cos*pupilOffset,y+sin*pupilOffset,pupilRadius,0,Math.PI*2);
+    bctx.fill();
+    bctx.fillStyle='rgba(255,255,255,0.75)';
+    bctx.beginPath();
+    bctx.arc(x+cos*pupilOffset*0.35,y+sin*pupilOffset*0.35,pupilRadius*0.35,0,Math.PI*2);
+    bctx.fill();
+  });
+  const tongueBase=size*0.46;
+  const tongueLength=size*0.45;
+  const tongueWidth=size*0.08;
+  const forkWidth=tongueWidth*1.7;
+  const baseX=cx+cos*tongueBase;
+  const baseY=cy+sin*tongueBase;
+  const tipX=cx+cos*(tongueBase+tongueLength);
+  const tipY=cy+sin*(tongueBase+tongueLength);
+  bctx.fillStyle='rgba(248,113,113,0.9)';
+  bctx.beginPath();
+  bctx.moveTo(baseX+perpX*tongueWidth,baseY+perpY*tongueWidth);
+  bctx.lineTo(tipX+perpX*forkWidth,tipY+perpY*forkWidth);
+  bctx.lineTo(tipX,tipY);
+  bctx.lineTo(tipX-perpX*forkWidth,tipY-perpY*forkWidth);
+  bctx.lineTo(baseX-perpX*tongueWidth,baseY-perpY*tongueWidth);
+  bctx.closePath();
+  bctx.fill();
+  bctx.restore();
+}
+
+function roundedRectPath(x,y,w,h,r){
+  const radius=Math.max(2,Math.min(r,Math.min(w,h)/2));
+  bctx.beginPath();
+  bctx.moveTo(x+radius,y);
+  bctx.arcTo(x+w,y,x+w,y+h,radius);
+  bctx.arcTo(x+w,y+h,x,y+h,radius);
+  bctx.arcTo(x,y+h,x,y,radius);
+  bctx.arcTo(x,y,x+w,y,radius);
+  bctx.closePath();
+}
+
+function fillRoundedRect(x,y,w,h,r){
+  roundedRectPath(x,y,w,h,r);
+  bctx.fill();
+}
+
+function strokeRoundedRect(x,y,w,h,r){
+  roundedRectPath(x,y,w,h,r);
+  bctx.stroke();
+}
+
 function drawOverlay(state){
   if(!window.overlayVisible) return;
   const ctx=bctx;
@@ -4384,18 +4533,6 @@ function drawPatternLabel(state){
   bctx.fillText(`Pattern: ${label}`,board.width-14,12);
   bctx.restore();
 }
-function drawRoundedRect(x,y,w,h,r){
-  const radius=Math.max(2,Math.min(r,Math.min(w,h)/2));
-  bctx.beginPath();
-  bctx.moveTo(x+radius,y);
-  bctx.arcTo(x+w,y,x+w,y+h,radius);
-  bctx.arcTo(x+w,y+h,x,y+h,radius);
-  bctx.arcTo(x,y+h,x,y,radius);
-  bctx.arcTo(x,y,x+w,y,radius);
-  bctx.closePath();
-  bctx.fill();
-}
-
 /* ---------------- App state ---------------- */
 const playbackModes={
   cinematic:{label:'Smooth realtime',frameMs:110,stepsPerFrame:1,renderEvery:1,queueTarget:60},
@@ -4777,6 +4914,8 @@ const ui={
   lrBadge:document.getElementById('lrBadge'),
   playbackLabel:document.getElementById('playbackLabel'),
   playbackButtons:Array.from(document.querySelectorAll('#playbackGroup .pill')),
+  liveSpeed:document.getElementById('liveSpeed'),
+  liveSpeedReadout:document.getElementById('liveSpeedReadout'),
   gridSize:document.getElementById('gridSize'),
   gridLabel:document.getElementById('gridLabel'),
   showPathOverlay:document.getElementById('showPathOverlay'),
@@ -4888,10 +5027,14 @@ const ui={
   rewardGrowthReadout:document.getElementById('rewardGrowthReadout'),
   rewardCompact:document.getElementById('rewardCompact'),
   rewardCompactReadout:document.getElementById('rewardCompactReadout'),
+  rewardCompactBonus:document.getElementById('rewardCompactBonus'),
+  rewardCompactBonusReadout:document.getElementById('rewardCompactBonusReadout'),
   bfsSlider:document.getElementById('bfsSlider'),
   bfsVal:document.getElementById('bfsVal'),
   hamSlider:document.getElementById('hamSlider'),
   hamVal:document.getElementById('hamVal'),
+  rewardHelperPenalty:document.getElementById('rewardHelperPenalty'),
+  rewardHelperPenaltyReadout:document.getElementById('rewardHelperPenaltyReadout'),
   usePathHelpers:document.getElementById('usePathHelpers'),
   kEpisodes:document.getElementById('kEpisodes'),
   kAvgRw:document.getElementById('kAvgRw'),
@@ -5358,6 +5501,20 @@ function updateTestSpeedFromUI(){
   if(ui.testSpeedValue){
     const delay=Math.round(testPlaybackDelay);
     ui.testSpeedValue.textContent=`${delay}\u202Fms`;
+  }
+}
+
+function updateLiveSpeedFromUI(){
+  if(!ui.liveSpeed) return;
+  const raw=Number(ui.liveSpeed.value);
+  if(Number.isFinite(raw)){
+    const ms=Math.max(30,Math.min(200,Math.round(raw)));
+    playbackModes.cinematic.frameMs=ms;
+    playbackModes.watch.frameMs=Math.max(40,ms+30);
+    if(ui.liveSpeedReadout){
+      ui.liveSpeedReadout.textContent=`${ms}\u202Fms`;
+    }
+    refreshPlaybackLabel();
   }
 }
 
@@ -5904,6 +6061,9 @@ function bindUI(){
   ui.testSpeed?.addEventListener('input',()=>{
     updateTestSpeedFromUI();
   });
+  ui.liveSpeed?.addEventListener('input',()=>{
+    updateLiveSpeedFromUI();
+  });
   ui.aiRunLimit?.addEventListener('change',()=>{
     applyAiRunLimitFromUI();
   });
@@ -5960,7 +6120,7 @@ function bindUI(){
     updateReadouts();
     applyEnvCountFromUI();
   });
-  const rewardIds=['rewardStep','rewardTurn','rewardApproach','rewardRetreat','rewardLoop','rewardTightLoop','rewardRevisit','rewardWall','rewardSelf','rewardTimeout','rewardTrap','rewardSpace','rewardDeadEnd','rewardFruit','rewardGrowth','rewardCompact'];
+  const rewardIds=['rewardStep','rewardTurn','rewardApproach','rewardRetreat','rewardLoop','rewardTightLoop','rewardRevisit','rewardWall','rewardSelf','rewardTimeout','rewardTrap','rewardSpace','rewardDeadEnd','rewardFruit','rewardGrowth','rewardCompact','rewardCompactBonus','rewardHelperPenalty'];
   const updateRewards=()=>{ updateRewardReadouts(); applyRewardsToEnv(); };
   rewardIds.forEach(id=>ui[id]?.addEventListener('input',updateRewards));
   ui.curriculumToggle?.addEventListener('change',()=>{
@@ -6038,6 +6198,7 @@ function bindUI(){
   updateAutoLogVisibility();
   updateAiIntervalReadout();
   updateTestSpeedFromUI();
+  updateLiveSpeedFromUI();
   syncTestLengthDisplays();
   setTestModeActive(false);
   setAiAutoStyle(aiAutoTuneStyle,{announce:false});
@@ -6224,13 +6385,25 @@ function setTrainingMode(mode){
   updateAiRunLimitHint();
   if(wasTraining&&!watching) startTraining();
 }
+function formatPlaybackLabel(){
+  if(liveViewHidden) return 'Rendering paused';
+  const mode=playbackModes[playbackMode]||playbackModes.cinematic;
+  const ms=Number.isFinite(mode.frameMs)?Math.round(mode.frameMs):null;
+  return ms?`${mode.label} • ${ms}\u202Fms`:mode.label;
+}
+
+function refreshPlaybackLabel(){
+  if(!ui.playbackLabel) return;
+  ui.playbackLabel.textContent=formatPlaybackLabel();
+}
+
 function setPlaybackMode(mode){
   if(!playbackModes[mode]) mode='cinematic';
   playbackMode=mode;
   ui.playbackButtons.forEach(btn=>{
     btn.classList.toggle('active',btn.dataset.speed===mode);
   });
-  ui.playbackLabel.textContent=liveViewHidden?'Rendering paused':playbackModes[mode].label;
+  refreshPlaybackLabel();
 }
 function setLiveViewHidden(hidden){
   hidden=!!hidden;
@@ -6251,7 +6424,7 @@ function setLiveViewHidden(hidden){
     renderActive=false;
     renderQueue.length=0;
     currentAnim=null;
-    ui.playbackLabel.textContent='Rendering paused';
+    refreshPlaybackLabel();
   }else{
     renderSuspended=false;
     setImmediateState(env);
@@ -6356,8 +6529,14 @@ function updateRewardReadouts(){
   ui.rewardFruitReadout.textContent=(+ui.rewardFruit.value).toFixed(1);
   ui.rewardGrowthReadout.textContent=(+ui.rewardGrowth.value).toFixed(1);
   ui.rewardCompactReadout.textContent=(+ui.rewardCompact.value).toFixed(3);
+  if(ui.rewardCompactBonusReadout){
+    ui.rewardCompactBonusReadout.textContent=(+ui.rewardCompactBonus.value).toFixed(2);
+  }
   ui.bfsVal.textContent=(+ui.bfsSlider.value).toFixed(2);
   ui.hamVal.textContent=(+ui.hamSlider.value).toFixed(2);
+  if(ui.rewardHelperPenaltyReadout){
+    ui.rewardHelperPenaltyReadout.textContent=(+ui.rewardHelperPenalty.value).toFixed(2);
+  }
   if(ui.curriculumLengthReadout){
     ui.curriculumLengthReadout.textContent=`${curriculumState.manualLength|0}`;
   }
@@ -6388,9 +6567,11 @@ function getRewardConfigFromUI(){
     fruitReward:+ui.rewardFruit.value,
     growthBonus:+ui.rewardGrowth.value,
     compactWeight:+ui.rewardCompact.value,
+    compactBonus:+ui.rewardCompactBonus.value,
     bfsWeight:+ui.bfsSlider.value,
     hamiltonWeight:+ui.hamSlider.value,
     usePathHelpers:ui.usePathHelpers.checked,
+    helperAlignmentPenalty:+ui.rewardHelperPenalty.value,
   };
 }
 function applyRewardsToEnv(){
@@ -6421,9 +6602,11 @@ function applyRewardConfigToUI(config={}){
   if(config.fruitReward!==undefined) ui.rewardFruit.value=config.fruitReward;
   if(config.growthBonus!==undefined) ui.rewardGrowth.value=config.growthBonus;
   if(config.compactWeight!==undefined) ui.rewardCompact.value=config.compactWeight;
+  if(config.compactBonus!==undefined) ui.rewardCompactBonus.value=config.compactBonus;
   if(config.bfsWeight!==undefined) ui.bfsSlider.value=config.bfsWeight;
   if(config.hamiltonWeight!==undefined) ui.hamSlider.value=config.hamiltonWeight;
   if(config.usePathHelpers!==undefined) ui.usePathHelpers.checked=!!config.usePathHelpers;
+  if(config.helperAlignmentPenalty!==undefined) ui.rewardHelperPenalty.value=config.helperAlignmentPenalty;
   updateRewardReadouts();
   applyRewardsToEnv();
 }


### PR DESCRIPTION
## Summary
- refresh the dashboard backdrop and board styling to highlight the snake with greener gradients and detailed head rendering
- add a live speed slider with millisecond readout and playback label updates to tune cinematic training pace
- expose compact bonus and helper alignment penalty sliders (plus readouts) so reward configuration stays in sync across UI, envs, and agents

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5763e61048324babb584135fd613a